### PR TITLE
chore: release 0.5.2 with automated PyPI publishing and updated documentation workflow

### DIFF
--- a/.cursor/commands/publish-to-pypi.md
+++ b/.cursor/commands/publish-to-pypi.md
@@ -1,0 +1,151 @@
+# Publish to PyPI
+
+## Overview
+
+This command helps you publish a new version of `testrail-api-module` to PyPI by creating a release tag that triggers the GitHub Actions workflow.
+
+## Prerequisites
+
+Before using this command, ensure:
+
+1. **PyPI API Token is configured**: The `PYPI_API_TOKEN` secret must be set in your GitHub repository (Settings → Secrets and variables → Actions)
+2. **Version is updated**: The version in `pyproject.toml` should match the tag you'll create
+3. **CHANGELOG is updated**: Move entries from `[Unreleased]` to a new version section
+
+## Process
+
+### 1. Verify Prerequisites
+
+Check that you have:
+- ✅ Updated `pyproject.toml` with the new version number
+- ✅ Updated `CHANGELOG.md` with a new version section
+- ✅ Committed all changes
+- ✅ `PYPI_API_TOKEN` secret configured in GitHub
+
+### 2. Determine Version Number
+
+Follow [Semantic Versioning](https://semver.org/):
+- **MAJOR** (1.0.0): Breaking changes
+- **MINOR** (0.1.0): New features (backward compatible)
+- **PATCH** (0.0.1): Bug fixes (backward compatible)
+
+**Current version**: Check `pyproject.toml` for the current version.
+
+### 3. Create the Release Tag
+
+The tag format should be either:
+- `v0.5.2` (with 'v' prefix - **recommended**)
+- `0.5.2` (without prefix)
+
+**Examples**:
+- `v0.5.2` - Standard release
+- `v1.0.0-alpha.1` - Pre-release (alpha)
+- `v1.0.0-beta.1` - Pre-release (beta)
+- `v1.0.0-rc.1` - Release candidate
+
+### 4. Create and Push Tag
+
+#### Using Git Commands (Recommended)
+
+```bash
+# Create an annotated tag with a message
+git tag -a v0.5.2 -m "Release v0.5.2"
+
+# Push the tag to trigger the workflow
+git push origin v0.5.2
+```
+
+#### Using GitHub Web Interface
+
+1. Go to your repository on GitHub
+2. Click **Releases** → **Create a new release**
+3. Choose a tag: Type `v0.5.2` → **Create new tag: v0.5.2 on publish**
+4. Fill in release title and description
+5. Click **Publish release**
+
+### 5. Monitor the Workflow
+
+1. Go to **Actions** tab in GitHub
+2. Find the "Publish to PyPI" workflow run
+3. Monitor the build and upload process
+4. Wait for completion (usually 2-5 minutes)
+
+### 6. Verify Publication
+
+After the workflow completes:
+
+1. Visit [PyPI project page](https://pypi.org/project/testrail-api-module/)
+2. Verify the new version appears
+3. Test installation: `pip install testrail-api-module==0.5.2`
+
+## Tag Format Rules
+
+The workflow accepts tags matching these patterns:
+- `v[0-9]+.[0-9]+.[0-9]+*` - Matches `v0.1.0`, `v1.2.3-beta`, etc.
+- `[0-9]+.[0-9]+.[0-9]+*` - Matches `0.1.0`, `1.2.3-beta`, etc.
+
+**Valid examples**:
+- ✅ `v0.5.2`
+- ✅ `v1.0.0`
+- ✅ `v2.0.0-alpha.1`
+- ✅ `0.5.2`
+- ✅ `1.0.0-beta.2`
+
+**Invalid examples**:
+- ❌ `release-0.5.2` (doesn't match pattern)
+- ❌ `version_0.5.2` (doesn't match pattern)
+- ❌ `v0.5` (missing patch version)
+
+## Complete Workflow Example
+
+```bash
+# 1. Update version in pyproject.toml (e.g., 0.5.2)
+# 2. Update CHANGELOG.md with new version section
+# 3. Commit changes
+git add pyproject.toml CHANGELOG.md
+git commit -m "Prepare release v0.5.2"
+
+# 4. Create and push tag
+git tag -a v0.5.2 -m "Release v0.5.2"
+git push origin v0.5.2
+
+# 5. Monitor workflow in GitHub Actions tab
+# 6. Verify on PyPI after workflow completes
+```
+
+## Troubleshooting
+
+### Workflow Not Triggering
+
+- **Check tag format**: Must match `v0.1.0` or `0.1.0` pattern
+- **Verify tag was pushed**: `git ls-remote --tags origin`
+- **Check Actions tab**: Look for workflow runs
+
+### Build/Upload Failures
+
+- **Version mismatch**: Tag version must match `pyproject.toml` version
+- **Token issues**: Verify `PYPI_API_TOKEN` secret is set correctly
+- **Version exists**: PyPI doesn't allow re-uploading the same version
+
+### Common Errors
+
+**"File already exists"**: Version already on PyPI - use a new version number
+
+**"Invalid authentication"**: Check `PYPI_API_TOKEN` secret in GitHub
+
+**"Invalid version"**: Ensure version in `pyproject.toml` is valid
+
+## Best Practices
+
+1. **Test locally first**: Run `python -m build` before tagging
+2. **Use annotated tags**: Include descriptive messages
+3. **Keep versions in sync**: Tag must match `pyproject.toml` version
+4. **Update changelog**: Document changes before releasing
+5. **Monitor workflow**: Watch Actions tab for issues
+
+## Related Documentation
+
+- **Full Guide**: See `docs/PYPI_PUBLISHING_GUIDE.md` for detailed instructions
+- **Workflow File**: `.github/workflows/publish.yml`
+- **Project Config**: `pyproject.toml`
+- **Changelog**: `CHANGELOG.md`

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,44 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      # Matches tags like v0.1.0, v1.2.3, 0.1.0, 1.2.3, etc.
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+      - '[0-9]+.[0-9]+.[0-9]+*'
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build dependencies
+        run: |
+          uv pip install --upgrade build twine
+
+      - name: Build package
+        run: |
+          uv run python -m build
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          uv run twine upload dist/*

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,10 +1,14 @@
-# Simple workflow for deploying static content to GitHub Pages
-name: Deploy static content to Pages
+# Workflow for publishing documentation to GitHub Pages
+# Runs automatically when release tags are pushed (same triggers as PyPI publish)
+name: Publish Documentation to GitHub Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
-    branches: ["main"]
+    tags:
+      # Matches tags like v0.1.0, v1.2.3, 0.1.0, 1.2.3, etc.
+      # Same pattern as the PyPI publish workflow
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+      - '[0-9]+.[0-9]+.[0-9]+*'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -22,8 +26,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Single deploy job since we're just deploying
-  deploy:
+  # Deploy documentation to GitHub Pages
+  deploy-docs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -51,12 +55,12 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
       
-      - name: Upload artifact
+      - name: Upload documentation artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload only the docs folder
+          # Upload only the docs folder containing generated documentation
           path: 'docs'
       
-      - name: Deploy to GitHub Pages
+      - name: Deploy documentation to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.2] 2026-01-23
+
+### ✨ Added
+
+- **Automated PyPI Publishing Workflow**: Added GitHub Actions workflow for automated PyPI publishing on release tags
+  - Workflow triggers automatically when tags matching semantic version patterns are pushed
+  - Supports tags with or without 'v' prefix (e.g., `v0.5.2` or `0.5.2`)
+  - Builds package using `uv` and `setuptools`
+  - Publishes to PyPI using secure API token from repository secrets
+  - Includes comprehensive publishing guide in `docs/PYPI_PUBLISHING_GUIDE.md`
+  - Added Cursor command (`.cursor/commands/publish-to-pypi.md`) for easy reference
+  - Impact: Simplifies release process and ensures consistent PyPI deployments
+
+### 🔧 Changed
+
+- **Documentation Publishing Workflow**: Updated GitHub Pages workflow to align with release process
+  - Changed trigger from `main` branch pushes to release tags (same pattern as PyPI publish workflow)
+  - Updated workflow name and descriptions to clearly indicate it's for publishing documentation
+  - Documentation now publishes automatically when release tags are created
+  - Impact: Documentation stays in sync with releases and is only published for tagged versions
 
 ## [0.5.1] - 2026-01-23
 

--- a/docs/PYPI_PUBLISHING_GUIDE.md
+++ b/docs/PYPI_PUBLISHING_GUIDE.md
@@ -1,0 +1,215 @@
+# PyPI Publishing Guide
+
+This guide explains how to publish new versions of `testrail-api-module` to PyPI using GitHub Actions and release tags.
+
+## Overview
+
+The project uses a GitHub Actions workflow that automatically builds and publishes to PyPI when you push a release tag. The workflow is triggered by tags matching semantic version patterns.
+
+## Prerequisites
+
+### 1. PyPI API Token
+
+Before publishing, you need to set up a PyPI API token in your GitHub repository secrets:
+
+1. **Create a PyPI API Token**:
+   - Go to [PyPI Account Settings](https://pypi.org/manage/account/)
+   - Navigate to "API tokens" section
+   - Click "Add API token"
+   - Give it a name (e.g., "GitHub Actions - testrail-api-module")
+   - Set the scope to the project: `testrail-api-module`
+   - Copy the token (it starts with `pypi-`)
+
+2. **Add Token to GitHub Secrets**:
+   - Go to your repository on GitHub
+   - Navigate to **Settings** → **Secrets and variables** → **Actions**
+   - Click **New repository secret**
+   - Name: `PYPI_API_TOKEN`
+   - Value: Paste your PyPI API token
+   - Click **Add secret**
+
+## Tag Format
+
+The workflow accepts tags in two formats:
+
+### Format 1: With 'v' Prefix (Recommended)
+```
+v0.1.0
+v1.2.3
+v2.0.0-beta.1
+v0.5.1
+```
+
+### Format 2: Without Prefix
+```
+0.1.0
+1.2.3
+2.0.0-beta.1
+0.5.1
+```
+
+### Supported Patterns
+
+The workflow matches tags using these patterns:
+- `v[0-9]+.[0-9]+.[0-9]+*` - Matches `v0.1.0`, `v1.2.3-beta`, etc.
+- `[0-9]+.[0-9]+.[0-9]+*` - Matches `0.1.0`, `1.2.3-beta`, etc.
+
+**Note**: The `*` at the end allows for pre-release versions like `v1.0.0-alpha.1` or `v2.0.0-rc.1`.
+
+## Publishing Process
+
+### Step 1: Update Version in `pyproject.toml`
+
+Before creating a tag, ensure the version in `pyproject.toml` matches the tag you'll create:
+
+```toml
+[project]
+version = "0.5.2"  # Update this to match your tag
+```
+
+### Step 2: Update CHANGELOG.md
+
+Move entries from the `[Unreleased]` section to a new version section:
+
+```markdown
+## [0.5.2] - 2026-01-23
+
+### ✨ Added
+- Your new features here
+
+### 🔧 Fixed
+- Your bug fixes here
+```
+
+### Step 3: Commit Your Changes
+
+```bash
+git add pyproject.toml CHANGELOG.md
+git commit -m "Prepare release v0.5.2"
+```
+
+### Step 4: Create and Push the Tag
+
+#### Option A: Using Git Commands
+
+```bash
+# Create an annotated tag (recommended)
+git tag -a v0.5.2 -m "Release v0.5.2"
+
+# Push the tag to GitHub
+git push origin v0.5.2
+```
+
+#### Option B: Using GitHub Web Interface
+
+1. Go to your repository on GitHub
+2. Click **Releases** → **Create a new release**
+3. Choose a tag:
+   - Click **Choose a tag** → Type `v0.5.2` → **Create new tag: v0.5.2 on publish**
+4. Fill in the release title and description
+5. Click **Publish release**
+
+**Note**: When you publish a release through GitHub's interface, it automatically creates and pushes the tag, which will trigger the workflow.
+
+### Step 5: Monitor the Workflow
+
+1. Go to your repository on GitHub
+2. Click the **Actions** tab
+3. You should see a workflow run named "Publish to PyPI"
+4. Click on it to monitor the build and publish process
+5. The workflow will:
+   - Checkout the code
+   - Set up Python and uv
+   - Install build dependencies
+   - Build the package (creates wheel and source distribution)
+   - Upload to PyPI
+
+### Step 6: Verify on PyPI
+
+After the workflow completes successfully:
+
+1. Visit [PyPI project page](https://pypi.org/project/testrail-api-module/)
+2. Verify your new version appears in the release history
+3. Test installation: `pip install testrail-api-module==0.5.2`
+
+## Version Numbering Guidelines
+
+Follow [Semantic Versioning](https://semver.org/) (SemVer):
+
+- **MAJOR** (1.0.0): Breaking changes
+- **MINOR** (0.1.0): New features (backward compatible)
+- **PATCH** (0.0.1): Bug fixes (backward compatible)
+
+### Pre-release Versions
+
+You can also publish pre-release versions:
+
+- **Alpha**: `v1.0.0-alpha.1`, `v1.0.0-alpha.2`
+- **Beta**: `v1.0.0-beta.1`, `v1.0.0-beta.2`
+- **Release Candidate**: `v1.0.0-rc.1`, `v1.0.0-rc.2`
+
+These are useful for testing before the final release.
+
+## Troubleshooting
+
+### Workflow Not Triggering
+
+- **Check tag format**: Ensure the tag matches the patterns (`v0.1.0` or `0.1.0`)
+- **Verify tag was pushed**: Run `git ls-remote --tags origin` to see remote tags
+- **Check Actions tab**: Look for any workflow runs or errors
+
+### Build Failures
+
+- **Version mismatch**: Ensure `pyproject.toml` version matches the tag
+- **Missing dependencies**: Check that all build dependencies are specified
+- **Syntax errors**: Run `python -m build` locally to test
+
+### PyPI Upload Failures
+
+- **Invalid token**: Verify `PYPI_API_TOKEN` secret is set correctly
+- **Token permissions**: Ensure the token has upload permissions for the project
+- **Version already exists**: PyPI doesn't allow re-uploading the same version
+- **Package name conflict**: Verify the package name in `pyproject.toml` is correct
+
+### Common Errors
+
+**Error**: `HTTPError: 400 Client Error: File already exists`
+- **Solution**: The version already exists on PyPI. Use a new version number.
+
+**Error**: `HTTPError: 403 Client Error: Invalid or non-existent authentication information`
+- **Solution**: Check that `PYPI_API_TOKEN` secret is set and the token is valid.
+
+**Error**: `ValueError: Invalid version: '0.5.1'`
+- **Solution**: Ensure the version in `pyproject.toml` is valid and matches the tag.
+
+## Best Practices
+
+1. **Always test locally first**: Run `python -m build` and `twine check dist/*` before tagging
+2. **Use annotated tags**: Include a message describing the release
+3. **Keep versions in sync**: Tag version should match `pyproject.toml` version
+4. **Update changelog**: Document all changes before releasing
+5. **Test installation**: After publishing, test installing the new version
+6. **Monitor workflow**: Watch the Actions tab to catch issues early
+
+## Quick Reference
+
+```bash
+# 1. Update version in pyproject.toml
+# 2. Update CHANGELOG.md
+# 3. Commit changes
+git add pyproject.toml CHANGELOG.md
+git commit -m "Prepare release v0.5.2"
+
+# 4. Create and push tag
+git tag -a v0.5.2 -m "Release v0.5.2"
+git push origin v0.5.2
+
+# 5. Monitor workflow in GitHub Actions tab
+# 6. Verify on PyPI
+```
+
+## Related Files
+
+- **Workflow**: `.github/workflows/publish.yml`
+- **Project config**: `pyproject.toml`
+- **Changelog**: `CHANGELOG.md`


### PR DESCRIPTION
- Introduced a GitHub Actions workflow for automated PyPI publishing on release tags, simplifying the release process.
- Updated the documentation publishing workflow to trigger on release tags, ensuring documentation is in sync with releases.
- Added a comprehensive publishing guide in `docs/PYPI_PUBLISHING_GUIDE.md` and a reference command in `.cursor/commands/publish-to-pypi.md`.