### PR TITLE
chore: Add .cursor/mcp.json to .gitignore to prevent credential exposure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ __private__/
 
 # Security reports
 .security_reports/
+
+# Cursor configuration (may contain sensitive credentials)
+.cursor/mcp.json


### PR DESCRIPTION
## Summary

This PR adds `.cursor/mcp.json` to `.gitignore` to prevent accidental commits of sensitive credentials.

## Changes

- Added `.cursor/mcp.json` to `.gitignore`
- Added comment explaining why this file should be ignored

## Security

The `.cursor/mcp.json` file contains sensitive TestRail API credentials and should never be committed to the repository. This change ensures it is properly excluded from version control.

## Testing

- ✅ Verified file is now ignored by git
- ✅ Confirmed file no longer appears in `git status`