### PR TITLE
Prepare release v0.5.6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,13 +2,12 @@ name: Publish to PyPI
 
 on:
   push:
-    # Only run when pushing a tag that matches AND the branch is "release"
+    # Trigger this workflow when a tag matching the version pattern is pushed.
     tags:
-      # Matches tags like v0.1.0, v1.2.3, 0.1.0, 1.2.3, etc.
       - 'v[0-9]+.[0-9]+.[0-9]+*'
       - '[0-9]+.[0-9]+.[0-9]+*'
-    branches:
-      - release
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -33,7 +32,11 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          uv pip install --upgrade build twine
+          uv pip install --system --upgrade build twine
+
+      - name: Clean previous builds
+        run: |
+          rm -rf dist/ build/ *.egg-info
 
       - name: Build package
         run: |
@@ -44,4 +47,4 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
-          uv run twine upload dist/*
+          twine upload dist/*

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -28,9 +28,6 @@ concurrency:
 jobs:
   # Deploy documentation to GitHub Pages
   deploy-docs:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.5] 2026-01-27
 
 
+## [0.5.6] 2026-01-27
+
+
 ## [Unreleased]
 
 ## [0.5.4] 2026-01-27

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "testrail-api-module"
-version = "0.5.5"
+version = "0.5.6"
 description = "A comprehensive Python wrapper for the TestRail API with enhanced error handling and performance improvements"
 authors = [
     { name = "Matt Troutman", email = "github@trtmn.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -2283,7 +2283,7 @@ wheels = [
 
 [[package]]
 name = "testrail-api-module"
-version = "0.5.5"
+version = "0.5.6"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Release v0.5.6

This PR prepares the release of version 0.5.6 by merging main into the release branch.

### Changes
- Version: 0.5.6
- Ready for release tagging

### Next Steps
After this PR is merged to release branch, use `--tag` flag to create and push the version tag.
