### PR TITLE
Fix f-string syntax for Python 3.11 CI

### DIFF
--- a/src/testrail_api_module/base.py
+++ b/src/testrail_api_module/base.py
@@ -152,8 +152,9 @@ class BaseAPI:
                 raise TestRailRateLimitError("Rate limit exceeded.")
 
         elif response.status_code >= 400:
-            error_message = f"API request failed with status {
-                response.status_code}"
+            error_message = (
+                f"API request failed with status {response.status_code}"
+            )
             try:
                 error_data = response.json()
                 if 'error' in error_data:


### PR DESCRIPTION
## Summary

- Fix multi-line f-string in `base.py:155` that is only valid in Python 3.12+
- Wraps in parentheses to support the Python 3.11 target used in CI
- Fixes the docs build failure on v0.6.0 tag

## Test plan

- [x] `test_base.py` passes (47 tests)
- [ ] Re-tag v0.6.0 after merge and verify docs workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)