### PR TITLE
Fix remaining f-string in base.py for Python 3.11

### DIFF
--- a/src/testrail_api_module/base.py
+++ b/src/testrail_api_module/base.py
@@ -170,8 +170,7 @@ class BaseAPI:
 
         else:
             raise TestRailAPIException(
-                f"Unexpected response status: {
-                    response.status_code}")
+                f"Unexpected response status: {response.status_code}")
 
     def _api_request(self,
                      method: str,


### PR DESCRIPTION
## Summary
- Fixed the second multi-line f-string in `base.py` line 173 that was missed in PR #63
- This was causing the docs build to fail with `SyntaxError: unterminated string literal`

## Test plan
- [ ] Verify docs build succeeds after merge and tag update

🤖 Generated with [Claude Code](https://claude.com/claude-code)