### PR TITLE
Fix README version heading, bump to v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.3] - 2026-02-19
+
+### 🐛 Fixed
+
+- Fixed incorrect version number in README breaking changes heading (was v0.7.0, should be v0.6.2)
+
 ## [0.6.2] - 2026-02-19
 
 ### 🚨 Breaking Changes

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A comprehensive Python wrapper for the TestRail API that provides easy access to
 - Easy-to-use interface
 - Support for both API key and password authentication
 
-## 🚨 Breaking Changes in v0.7.0
+## 🚨 Breaking Changes in v0.6.3
 
 **API parity audit.** All endpoints were audited against the [official TestRail API reference](https://support.testrail.com/hc/en-us/sections/7077196685204-Reference). Several methods were renamed, restructured, or removed to match the real API. See details below.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "testrail-api-module"
-version = "0.6.2"
+version = "0.6.3"
 description = "A comprehensive Python wrapper for the TestRail API with enhanced error handling and performance improvements"
 authors = [
     { name = "Matt Troutman", email = "github@trtmn.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -1115,7 +1115,7 @@ wheels = [
 
 [[package]]
 name = "testrail-api-module"
-version = "0.6.2"
+version = "0.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "mypy" },


### PR DESCRIPTION
## Summary
- Fix incorrect version in README breaking changes heading (was v0.7.0, now v0.6.3)
- Bump version to 0.6.3

## Test plan
- [ ] CI tests pass across Python 3.11, 3.12, 3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)