### PR TITLE
chore: automate release pipeline via GitHub Actions (v0.6.4)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,6 @@
-name: Publish Docs and Package
+name: Publish Docs and Package (manual)
 
 on:
-  push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+*'
-      - '[0-9]+.[0-9]+.[0-9]+*'
   workflow_dispatch:
 
 permissions:
@@ -71,20 +67,16 @@ jobs:
           python-version: "3.11"
 
       - name: Install build dependencies
-        run: |
-          uv pip install --system --upgrade build twine
+        run: uv pip install --system --upgrade build twine
 
       - name: Clean previous builds
-        run: |
-          rm -rf dist/ build/ *.egg-info
+        run: rm -rf dist/ build/ *.egg-info
 
       - name: Build package
-        run: |
-          uv build
+        run: uv build
 
       - name: Publish to PyPI
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          twine upload dist/*
+        run: twine upload dist/*

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,17 +1,24 @@
-name: Tag release on merge to main
+name: Tag and release on merge to main
 
 on:
   pull_request:
     types: [closed]
     branches: [main]
 
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "release"
+  cancel-in-progress: false
+
 jobs:
   tag:
     name: Create version tag
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
 
     steps:
       - name: Checkout
@@ -46,3 +53,79 @@ jobs:
             "github-actions[bot]@users.noreply.github.com"
           git tag "v${{ steps.version.outputs.version }}"
           git push origin "v${{ steps.version.outputs.version }}"
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag_exists: ${{ steps.tag_check.outputs.exists }}
+
+  deploy-docs:
+    name: Build and deploy documentation
+    needs: tag
+    if: needs.tag.outputs.tag_exists == 'false'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Generate documentation
+        run: uv run python utilities/generate_docs.py
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload documentation artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'docs'
+
+      - name: Deploy documentation to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+  publish:
+    name: Build and publish to PyPI
+    needs: deploy-docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build dependencies
+        run: uv pip install --system --upgrade build twine
+
+      - name: Clean previous builds
+        run: rm -rf dist/ build/ *.egg-info
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: twine upload dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.4] - 2026-02-19
+
+### 🔄 Maintenance
+
+- Automated release workflow: version tags are now created automatically by GitHub Actions when a PR is merged to `main`, which then triggers docs deployment and PyPI publishing in a single pipeline
+- Added `tag-release.yml` workflow; `publish.yml` is now manual-only
+
 ## [0.6.3] - 2026-02-19
 
 ### 🐛 Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "testrail-api-module"
-version = "0.6.3"
+version = "0.6.4"
 description = "A comprehensive Python wrapper for the TestRail API with enhanced error handling and performance improvements"
 authors = [
     { name = "Matt Troutman", email = "github@trtmn.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -1115,7 +1115,7 @@ wheels = [
 
 [[package]]
 name = "testrail-api-module"
-version = "0.6.3"
+version = "0.6.4"
 source = { editable = "." }
 dependencies = [
     { name = "mypy" },


### PR DESCRIPTION
## Summary

- `tag-release.yml` now owns the full release pipeline on PR merge to `main`: creates version tag → deploys docs → publishes to PyPI, all in one workflow
- `publish.yml` is now manual-only (`workflow_dispatch`) as an escape hatch
- Removes the requirement for developers to manually push version tags
- Also bumps version to 0.6.4

## Test plan

- [ ] CI tests pass across Python 3.11, 3.12, 3.13
- [ ] On merge, `tag-release.yml` creates `v0.6.4` tag and triggers docs + PyPI publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)