### PR TITLE
Fix README repo links, bump to v0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.5] - 2026-02-19
+
+### 🐛 Fixed
+
+- Fixed GitHub Source badge and docs link in README using hyphens instead of underscores for repo name
+
 ## [0.6.4] - 2026-02-19
 
 ### 🔄 Maintenance

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # testrail_api_module
 
-[![PyPI - Version](https://img.shields.io/pypi/v/testrail-api-module?label=Latest%20Version)](https://pypi.org/project/testrail-api-module/) [![PyPI - Downloads](https://img.shields.io/pypi/dm/testrail-api-module?color=purple)](https://pypi.org/project/testrail-api-module/) [![GitHub Source](https://img.shields.io/badge/github-source-blue?logo=github)](https://github.com/trtmn/testrail-api-module/) [![PyPI Stats](https://img.shields.io/badge/%20%F0%9F%94%97-blue?label="📈%20Stats")](https://pypistats.org/packages/testrail-api-module/) [![Docs](https://img.shields.io/pypi/v/testrail-api-module?label=📖%20Docs&color=blue)](https://trtmn.github.io/testrail_api_module/)
+[![PyPI - Version](https://img.shields.io/pypi/v/testrail-api-module?label=Latest%20Version)](https://pypi.org/project/testrail-api-module/) [![PyPI - Downloads](https://img.shields.io/pypi/dm/testrail-api-module?color=purple)](https://pypi.org/project/testrail-api-module/) [![GitHub Source](https://img.shields.io/badge/github-source-blue?logo=github)](https://github.com/trtmn/testrail_api_module/) [![PyPI Stats](https://img.shields.io/badge/%20%F0%9F%94%97-blue?label="📈%20Stats")](https://pypistats.org/packages/testrail-api-module/) [![Docs](https://img.shields.io/pypi/v/testrail-api-module?label=📖%20Docs&color=blue)](https://trtmn.github.io/testrail_api_module/)
 
 A comprehensive Python wrapper for the TestRail API that provides easy access to all TestRail functionalities.
 
@@ -282,7 +282,7 @@ except Exception as e:
 ## Documentation
 
 For complete documentation, visit our
-[docs](https://trtmn.github.io/testrail-api-module/).
+[docs](https://trtmn.github.io/testrail_api_module/).
 
 ## Dependency Management
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "testrail-api-module"
-version = "0.6.4"
+version = "0.6.5"
 description = "A comprehensive Python wrapper for the TestRail API with enhanced error handling and performance improvements"
 authors = [
     { name = "Matt Troutman", email = "github@trtmn.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -1115,7 +1115,7 @@ wheels = [
 
 [[package]]
 name = "testrail-api-module"
-version = "0.6.4"
+version = "0.6.5"
 source = { editable = "." }
 dependencies = [
     { name = "mypy" },


### PR DESCRIPTION
## Summary
- Fix GitHub Source badge link: `testrail-api-module` → `testrail_api_module`
- Fix docs link: same hyphen-to-underscore correction

## Test plan
- [ ] CI tests pass across Python 3.11, 3.12, 3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)