### PR TITLE
Require GitHub issue for all work; link branch names to issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adopted git-flow branching strategy: `development` as integration branch, `main` for releases only
 - Added `development` branch to CI test triggers
 - Updated release skill to follow dev→main PR workflow
+- Require GitHub issue before starting work; branch names must include issue number (e.g., `81-description`)
 
 ## [0.6.6] - 2026-02-19
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,26 @@ A Python wrapper for the TestRail REST API (`testrail-api-module` on PyPI). Requ
 
 ## Branching Strategy
 
-This project uses a git-flow workflow:
+This project uses a git-flow workflow with issue-linked branches.
+
+### Before starting work
+
+Every piece of work must have an associated GitHub issue. If one doesn't exist, create it first with `gh issue create`. This ensures all changes are tracked and linked.
+
+### Branches
 
 - **`main`** — production releases only, protected branch
 - **`development`** — integration branch, all feature work merges here
 - **Feature/fix branches** — branch from `development`, PR back to `development`
 - **Releases** — PR from `development` → `main` (merge triggers automatic tagging + PyPI publish)
+
+Branch names must include the issue number so GitHub auto-links them:
+
+```
+<issue-number>-short-description
+```
+
+Examples: `81-require-issue-branch-naming`, `42-fix-auth-bug`, `15-add-milestones-api`
 
 Always work on `development` or a feature branch. Never commit directly to `main`.
 


### PR DESCRIPTION
Closes #81

## Summary
- Document in CLAUDE.md that every piece of work must have an associated GitHub issue before starting
- Branch naming convention: `<issue-number>-short-description` (GitHub auto-links these to issues)
- Updated changelog

## Test plan
- [ ] CI passes
- [ ] CLAUDE.md branching strategy section is clear and complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)