### PR TITLE
Require updating GitHub issues with progress comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `development` branch to CI test triggers
 - Updated release skill to follow dev→main PR workflow
 - Require GitHub issue before starting work; branch names must include issue number (e.g., `81-description`)
+- Require updating GitHub issues with progress comments throughout work
 
 ## [0.6.6] - 2026-02-19
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,15 @@ This project uses a git-flow workflow with issue-linked branches.
 
 Every piece of work must have an associated GitHub issue. If one doesn't exist, create it first with `gh issue create`. This ensures all changes are tracked and linked.
 
+### Updating issues
+
+Keep the GitHub issue updated throughout the work:
+
+- Comment when starting work on the issue
+- Comment with progress on multi-step tasks (e.g., "Tests passing, working on docs")
+- Reference blockers or decisions made along the way
+- The PR description should include `Closes #<number>` to auto-close the issue on merge
+
 ### Branches
 
 - **`main`** — production releases only, protected branch


### PR DESCRIPTION
Closes #83

## Summary
- Add "Updating issues" section to CLAUDE.md branching strategy
- Requires commenting on issues when starting work, on progress, and on blockers/decisions
- PR descriptions should include `Closes #<number>` to auto-close issues

## Test plan
- [ ] CI passes
- [ ] CLAUDE.md reads clearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)