### PR TITLE
Close issues when PR merges to development with passing CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated release skill to follow dev→main PR workflow
 - Require GitHub issue before starting work; branch names must include issue number (e.g., `81-description`)
 - Require updating GitHub issues with progress comments throughout work
+- Close issues when PR merges to `development` with passing CI
 
 ## [0.6.6] - 2026-02-19
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Keep the GitHub issue updated throughout the work:
 - Comment when starting work on the issue
 - Comment with progress on multi-step tasks (e.g., "Tests passing, working on docs")
 - Reference blockers or decisions made along the way
-- The PR description should include `Closes #<number>` to auto-close the issue on merge
+- Close the issue with `gh issue close <number>` once its PR merges to `development` with passing CI — don't wait for the release to `main`
 
 ### Branches
 


### PR DESCRIPTION
Closes #85

## Summary
- Issues should be closed once their PR merges to `development` with passing CI
- No need to wait for the release PR to `main`

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)