### PR TITLE
Change default branch to development for auto-closing issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Require GitHub issue before starting work; branch names must include issue number (e.g., `81-description`)
 - Require updating GitHub issues with progress comments throughout work
 - Close issues when PR merges to `development` with passing CI
+- Changed default branch to `development` so `Closes #N` auto-closes issues
 
 ## [0.6.6] - 2026-02-19
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,12 +21,12 @@ Keep the GitHub issue updated throughout the work:
 - Comment when starting work on the issue
 - Comment with progress on multi-step tasks (e.g., "Tests passing, working on docs")
 - Reference blockers or decisions made along the way
-- Close the issue with `gh issue close <number>` once its PR merges to `development` with passing CI — don't wait for the release to `main`
+- PR descriptions should include `Closes #<number>` — GitHub auto-closes the issue when the PR merges to `development` (the default branch)
 
 ### Branches
 
 - **`main`** — production releases only, protected branch
-- **`development`** — integration branch, all feature work merges here
+- **`development`** — default branch, integration branch, all feature work merges here
 - **Feature/fix branches** — branch from `development`, PR back to `development`
 - **Releases** — PR from `development` → `main` (merge triggers automatic tagging + PyPI publish)
 


### PR DESCRIPTION
Closes #87

## Summary
- Changed GitHub default branch from `main` to `development`
- `Closes #N` in PRs to `development` now auto-closes issues on merge
- Updated CLAUDE.md to reflect the default branch and simplify issue closing guidance

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)