### PR TITLE
Fix PyPI Stats badge broken link in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Close issues when PR merges to `development` with passing CI
 - Changed default branch to `development` so `Closes #N` auto-closes issues
 
+### 🐛 Fixed
+
+- Fixed PyPI Stats badge broken link in README (trailing slash)
+
 ## [0.6.6] - 2026-02-19
 
 ### 🐛 Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # testrail_api_module
 
-[![PyPI - Version](https://img.shields.io/pypi/v/testrail-api-module?label=Latest%20Version)](https://pypi.org/project/testrail-api-module/) [![PyPI - Downloads](https://img.shields.io/pypi/dm/testrail-api-module?color=purple)](https://pypi.org/project/testrail-api-module/) [![GitHub Source](https://img.shields.io/badge/github-source-blue?logo=github)](https://github.com/trtmn/testrail_api_module/) [![PyPI Stats](https://img.shields.io/badge/%20%F0%9F%94%97-blue?label="📈%20Stats")](https://pypistats.org/packages/testrail-api-module/) [![Docs](https://img.shields.io/pypi/v/testrail-api-module?label=📖%20Docs&color=blue)](https://trtmn.github.io/testrail_api_module/)
+[![PyPI - Version](https://img.shields.io/pypi/v/testrail-api-module?label=Latest%20Version)](https://pypi.org/project/testrail-api-module/) [![PyPI - Downloads](https://img.shields.io/pypi/dm/testrail-api-module?color=purple)](https://pypi.org/project/testrail-api-module/) [![GitHub Source](https://img.shields.io/badge/github-source-blue?logo=github)](https://github.com/trtmn/testrail_api_module/) [![PyPI Stats](https://img.shields.io/badge/%20%F0%9F%94%97-blue?label="📈%20Stats")](https://pypistats.org/packages/testrail-api-module) [![Docs](https://img.shields.io/pypi/v/testrail-api-module?label=📖%20Docs&color=blue)](https://trtmn.github.io/testrail_api_module/)
 
 A comprehensive Python wrapper for the TestRail API that provides easy access to all TestRail functionalities.
 


### PR DESCRIPTION
Closes #77

## Summary
- Remove trailing slash from pypistats.org URL in README badge

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)