### PR TITLE
fix(results): annotate add_results_for_cases return as list (#100)

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD024": { "siblings_only": true }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### 🐛 Fixed
+
+- `ResultsAPI.add_results_for_cases` return type annotation corrected from
+  `dict[str, Any]` to `list[dict[str, Any]]` to match the TestRail API, which
+  returns an unpaginated list of result objects. Both `results.py` and
+  `results.pyi` updated; regression test pins the annotation via
+  `typing.get_type_hints` (#100, #102).
+
 ## [0.7.0] - 2026-02-19
 
 ### 🚨 Breaking Changes

--- a/src/testrail_api_module/results.py
+++ b/src/testrail_api_module/results.py
@@ -177,7 +177,7 @@ class ResultsAPI(BaseAPI):
 
     def add_results_for_cases(
         self, run_id: int, results: list[dict[str, Any]]
-    ) -> dict[str, Any]:
+    ) -> list[dict[str, Any]]:
         """
         Add multiple test results for test cases in a test run.
 
@@ -195,7 +195,7 @@ class ResultsAPI(BaseAPI):
                     - custom_fields: Optional dictionary of custom field values
 
         Returns:
-            Dict containing the created test results data.
+            List of created test result dicts (one per submitted case).
 
         Raises:
             TestRailAPIError: If the API request fails.

--- a/src/testrail_api_module/results.pyi
+++ b/src/testrail_api_module/results.pyi
@@ -41,7 +41,7 @@ class ResultsAPI(BaseAPI):
         """Add a test result for a specific test case in a test run."""
     def add_results_for_cases(
         self, run_id: int, results: list[dict[str, Any]]
-    ) -> dict[str, Any]:
+    ) -> list[dict[str, Any]]:
         """Add multiple test results for test cases in a test run."""
     def get_results_for_case(
         self, run_id: int, case_id: int

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -571,6 +571,20 @@ class TestResultsAPI:
             )
             assert result == [{"id": 1}, {"id": 2}]
 
+    def test_add_results_for_cases_return_annotation_is_list(
+        self, results_api: ResultsAPI
+    ) -> None:
+        """Regression: return type must be list[dict[str, Any]], not dict[str, Any] (#100)."""
+        import inspect
+        import typing
+
+        sig = inspect.signature(results_api.add_results_for_cases)
+        hints = typing.get_type_hints(results_api.add_results_for_cases)
+        assert hints["return"] == list[dict[str, typing.Any]], (
+            f"add_results_for_cases must return list[dict[str, Any]], "
+            f"got {sig.return_annotation!r}"
+        )
+
     def test_add_results_for_cases_empty_list(
         self, results_api: ResultsAPI
     ) -> None:


### PR DESCRIPTION
Closes #100.

`add_results_for_cases` and its stub in `results.pyi` were annotated as `-> dict[str, Any]`, but the TestRail bulk endpoint returns a list of result dicts (one per submitted case). The sibling `add_results` already uses `-> list[dict[str, Any]]`. Updated both the runtime annotation and the stub, fixed the docstring, and added a regression test that pins the annotation via `typing.get_type_hints`.

All 62 tests in `tests/test_results.py` pass. Ruff clean.