### PR TITLE
chore: gitignore .claude/agent-memory, .claude/agents, .1password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,11 @@ bandit-report.html
 
 # Claude Code local settings
 .claude/settings.local.json
+.claude/agent-memory/
+.claude/agents/
+
+# 1Password CLI local config
+.1password/
 
 # Git worktrees
 .worktrees/


### PR DESCRIPTION
## Summary

Adds three directories to `.gitignore` to prevent accidental commits of local-machine state:

- `.claude/agent-memory/` — agent persistent state with absolute `/Users/<name>/` paths
- `.claude/agents/` — local agent definitions (often hard-code per-user paths)
- `.1password/` — 1Password CLI local config (e.g. `environments.toml`)

`.gitignore` already covered `.claude/settings.local.json` but not these.

All three are currently untracked on the maintainer's machine — this is preventive, not a fix for an active leak.

Closes #105.

## Test plan

- [x] `git status` no longer lists the three directories as untracked
- [x] Pre-commit hooks pass
- [ ] No CHANGELOG entry — tooling-only, not user-visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)