### PR TITLE
docs: use absolute URL for TRAM logo so it renders on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="tram.png" alt="TRAM Logo" width="400">
+  <img src="https://raw.githubusercontent.com/trtmn/testrail_api_module/main/tram.png" alt="TRAM Logo" width="400">
 </p>
 
 # TRAM — TestRail API Module


### PR DESCRIPTION
## Summary

One-line README change: switch the TRAM logo `<img>` from the relative path `tram.png` to its absolute `raw.githubusercontent.com` URL.

PyPI's renderer does not resolve relative image paths in `long_description`, so the logo currently renders as the alt-text placeholder "TRAM Logo" on https://pypi.org/project/testrail-api-module/. GitHub's repo view resolves the relative path correctly, which is why the bug was invisible during development.

Renders identically on both GitHub and PyPI after this change. Image verified reachable: `HTTP/2 200`, `content-type: image/png`, `content-length: 77033`.

Closes #109.

## Test plan

- [x] README diff is one line
- [ ] PR CI green
- [ ] After merge into main and re-publish, PyPI project page shows the logo

🤖 Generated with [Claude Code](https://claude.com/claude-code)