### PR TITLE
release: 0.7.2 version bump + changelog (prepare for main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.2] - 2026-05-22
 
 ### 🐛 Fixed
 
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   returns an unpaginated list of result objects. Both `results.py` and
   `results.pyi` updated; regression test pins the annotation via
   `typing.get_type_hints` (#100, #102).
+- TRAM logo on the PyPI project page (was rendering as a broken-image
+  placeholder). README now references the logo by absolute
+  `raw.githubusercontent.com` URL so PyPI's renderer can resolve it
+  (#109, #110).
 
 ### 🔄 Maintenance
 
@@ -22,8 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   containing absolute `/Users/<name>/` paths (#105, #106).
 - Back-merge `main` into `development` to reconverge branches after the
   0.7.1 release work landed directly on `main`. Adds `enforce_admins`
-  branch protection on `main` and a required Tests status check to
-  prevent future drift (#107).
+  branch protection on `main` and a required Tests status check
+  (Python 3.11/3.12/3.13/3.14) to prevent future drift (#107, #108).
 
 ## [0.7.1] - 2026-04-14
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "testrail-api-module"
-version = "0.7.1"
+version = "0.7.2"
 description = "A comprehensive Python wrapper for the TestRail API with enhanced error handling and performance improvements"
 authors = [
     { name = "Matt Troutman", email = "github@trtmn.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -1062,7 +1062,7 @@ wheels = [
 
 [[package]]
 name = "testrail-api-module"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Prepare release 0.7.2

Bumps `pyproject.toml` to `0.7.2` and moves the `[Unreleased]` CHANGELOG block under `## [0.7.2] - 2026-05-22`. This is the *prep* PR that lands on `development`; the actual release PR will be `development → main` immediately after this merges.

Doing it as two PRs avoids the drift pattern we just had to fix (#107): the version bump must exist on `development` before the release PR to `main`, otherwise `development` ends up behind `main` again.

### What's in 0.7.2

**🐛 Fixed**
- `ResultsAPI.add_results_for_cases` return type — `dict[str, Any]` → `list[dict[str, Any]]` (#100, #102)
- TRAM logo broken on PyPI page (#109, #110)

**🔄 Maintenance**
- Gitignore agent state directories (#105, #106)
- Back-merge `main` → `development`; tighten `main` branch protection (#107, #108)

### Verification

- [x] `uv run tox` — all four Python versions pass (418 tests each)
- [x] `uv version --short` reports `0.7.2`
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)