### PR TITLE
chore(deps): bump Pygments 2.19.2 → 2.20.0; commit dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      uv:
+        patterns: ["*"]
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns: ["*"]
+    labels:
+      - "dependencies"
+      - "ci"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### 🔄 Maintenance
+
+- Bump transitive `Pygments` from 2.19.2 to 2.20.0 to resolve a low-severity
+  ReDoS advisory (CVE-2026-4539 / GHSA-5239-wwwm-4pmq). Pygments is
+  dev-only — pulled in by `pdoc`, `pytest`, and `rich` — so this does
+  not affect published-wheel users (#114).
+- Commit `.github/dependabot.yml` codifying the previously UI-only
+  Dependabot configuration: weekly updates for both the `uv` ecosystem
+  and `github-actions`, with both ecosystems grouped into a single PR
+  each (#114).
+
 ## [0.7.2] - 2026-05-22
 
 ### 🐛 Fixed

--- a/uv.lock
+++ b/uv.lock
@@ -848,11 +848,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Two related dependency hygiene items in one PR — closes #114.

### 1. Pygments bump (Dependabot alert #3)

- **CVE-2026-4539** / **GHSA-5239-wwwm-4pmq** — low-severity ReDoS in Pygments' GUID-matching regex
- Bumped via `uv lock --upgrade-package pygments` (transitive — no `pyproject.toml` change)
- `2.19.2 → 2.20.0`
- **End-user impact: none.** Pygments is pulled in only by dev deps (`pdoc`, `pytest`, `rich`) and is not in the published wheel/sdist

### 2. Commit `.github/dependabot.yml`

Dependabot was already opening update PRs (e.g. #103, "Bump the uv group"), but the config lived in the repo's UI Security settings. Checking it in:

- Makes the cadence and grouping reviewable in the repo
- Survives accidental UI toggles
- Adds the `github-actions` ecosystem (would have flagged the Node 20 deprecation warning we've been seeing on every CI run)

Config:

\`\`\`yaml
version: 2
updates:
  - package-ecosystem: "uv"
    directory: "/"
    schedule: { interval: "weekly", day: "monday" }
    open-pull-requests-limit: 5
    groups: { uv: { patterns: ["*"] } }
    labels: ["dependencies"]

  - package-ecosystem: "github-actions"
    directory: "/"
    schedule: { interval: "weekly", day: "monday" }
    open-pull-requests-limit: 5
    groups: { actions: { patterns: ["*"] } }
    labels: ["dependencies", "ci"]
\`\`\`

## Test plan

- [x] `uv run pytest` — 418 passed
- [x] `CHANGELOG.md` `[Unreleased] → 🔄 Maintenance` entry added
- [ ] CI green
- [ ] Dependabot alert #3 closes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)