### PR TITLE
release: 0.7.3 version bump + changelog (prepare for main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.3] - 2026-05-22
 
 ### 🔄 Maintenance
 
 - Bump transitive `Pygments` from 2.19.2 to 2.20.0 to resolve a low-severity
   ReDoS advisory (CVE-2026-4539 / GHSA-5239-wwwm-4pmq). Pygments is
   dev-only — pulled in by `pdoc`, `pytest`, and `rich` — so this does
-  not affect published-wheel users (#114).
+  not affect published-wheel users (#114, #115).
 - Commit `.github/dependabot.yml` codifying the previously UI-only
   Dependabot configuration: weekly updates for both the `uv` ecosystem
   and `github-actions`, with both ecosystems grouped into a single PR
-  each (#114).
+  each (#114, #115).
+- Document the new release workflow in `.claude/skills/release/SKILL.md`:
+  pre-release drift check, local `tox` run, two-PR flow
+  (release-branch → development → main), PyPI verification, and
+  GitHub release creation (#113).
 
 ## [0.7.2] - 2026-05-22
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "testrail-api-module"
-version = "0.7.2"
+version = "0.7.3"
 description = "A comprehensive Python wrapper for the TestRail API with enhanced error handling and performance improvements"
 authors = [
     { name = "Matt Troutman", email = "github@trtmn.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -1062,7 +1062,7 @@ wheels = [
 
 [[package]]
 name = "testrail-api-module"
-version = "0.7.2"
+version = "0.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Prepare release 0.7.3

Bumps \`pyproject.toml\` to \`0.7.3\` and renames \`[Unreleased]\` → \`[0.7.3] - 2026-05-22\` in CHANGELOG.

This is the prep PR onto \`development\`; the actual release PR \`development → main\` follows immediately after merge.

### What's in 0.7.3 (all 🔄 Maintenance)

- Pygments 2.19.2 → 2.20.0 — closes Dependabot alert #3 (CVE-2026-4539, dev-only) (#114, #115)
- Commit \`.github/dependabot.yml\` codifying weekly uv + github-actions updates (#114, #115)
- Document the new release workflow in \`.claude/skills/release/SKILL.md\` (#113)

### Verification

- [x] Drift check: \`main\` has no unique content vs \`development\`
- [x] \`uv run tox\` — all four Python versions pass (418 tests each)
- [x] \`uv version --short\` reports \`0.7.3\`
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)