### PR TITLE
release: 0.7.3

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -3,7 +3,8 @@ name: release
 description: >
   Use this skill when the user asks to release a new version, publish to PyPI,
   bump the version, or cut a release. Handles the full release
-  workflow: version bump, changelog update, commit, PR, and merge.
+  workflow: version bump, changelog update, commit, PR, merge, PyPI verify,
+  and GitHub release.
 user_invocable: true
 ---
 
@@ -16,6 +17,7 @@ This skill handles the full release pipeline for `testrail_api_module`.
 - All code changes for the release are already merged into `development`
 - You are on the `development` branch
 - The `[Unreleased]` section in `CHANGELOG.md` has content
+- `gh` is authenticated and has push access to the repo
 
 ## Arguments
 
@@ -31,14 +33,37 @@ If no argument is given, default to `patch`.
 
 ## Steps
 
-### 1. Ensure you are on `development`
+### 1. Ensure you are on `development` and up to date
 
 ```bash
 git checkout development
 git pull origin development
 ```
 
-### 2. Determine the new version
+### 2. Verify branches haven't drifted
+
+```bash
+git fetch origin --quiet
+git log --oneline origin/main..origin/development | head
+git log --oneline origin/development..origin/main | head
+```
+
+`development` should be **ahead** of `main`, never behind. If `main` has
+commits not on `development`, stop and back-merge `main` into `development`
+first (see `#107` / `#108` for the canonical pattern). Releasing without
+fixing this drift would downgrade `pyproject.toml` and drop work.
+
+### 3. Run the full multi-version test suite locally
+
+```bash
+uv run tox
+```
+
+All supported Python versions (3.11, 3.12, 3.13, 3.14) must pass. CI will
+run the same matrix on the release PR, but verifying locally catches
+regressions before opening the PR and saves a round-trip.
+
+### 4. Determine and apply the new version
 
 ```bash
 # Check current version
@@ -50,89 +75,161 @@ uv version --bump <patch|minor|major>
 uv version <version>
 ```
 
-Store the new version number for use in later steps.
+Store the new version number for use in later steps. `uv version` updates
+both `pyproject.toml` and `uv.lock`.
 
-### 3. Update CHANGELOG.md
+### 5. Update CHANGELOG.md
 
-- Read `CHANGELOG.md`
-- Replace `## [Unreleased]` with `## [<version>] - <YYYY-MM-DD>`
-  using today's date
-- Verify the changelog entry has content (at minimum an Added,
-  Changed, or Fixed section)
-- Do NOT add a new empty `[Unreleased]` section — that will be
-  done in the next development cycle
+- Replace `## [Unreleased]` with `## [<version>] - <YYYY-MM-DD>` using today's date
+- Verify the changelog block has content (at minimum a `### Added`,
+  `### Changed`, or `### Fixed` section)
+- Do NOT add a new empty `[Unreleased]` section — that's added in the
+  next development cycle when the first PR after release lands
 
-### 4. Commit all changes on `development`
+### 6. Commit on a release branch (not directly on `development`)
 
-- Stage all changes: `git add -A`
-- Commit with a descriptive message summarizing the release
-- If pre-commit hooks fail:
-  - Fix the issues (ruff, trailing whitespace, etc.)
-  - Re-stage and retry the commit
-  - If only pre-existing issues remain (markdownlint line lengths,
-    bandit config errors, mypy duplicate module), use `--no-verify`
-  - Never use `--no-verify` to skip fixable issues like ruff errors
-
-### 5. Push `development` and create PR to `main`
+Auto-mode and convention both block direct commits to `development`.
+Branch off, commit, push, PR back to `development`.
 
 ```bash
-git push origin development
+git checkout -b release-<version> development
+git add pyproject.toml uv.lock CHANGELOG.md
+PATH="$PWD/.venv/bin:$PATH" git commit -m "release: <version>"
+git push -u origin release-<version>
+```
 
-gh pr create --base main --head development \
-  --title "<summary> v<version>" --body "$(cat <<'EOF'
-## Summary
-<bullet points summarizing changes>
+Notes:
 
-## Test plan
-- [ ] CI tests pass across Python 3.11, 3.12, 3.13
-- [ ] Docs build succeeds
+- Use `release-<version>` (single dash, no slash) — `release/<version>`
+  collides with the stale `release` branch on origin
+- `PATH=...` makes pre-commit hooks find the venv's `pre-commit` binary
+- Stage only the three release files. `git add -A` can pick up untracked
+  agent state or tooling config
 
-Generated with [Claude Code](https://claude.com/claude-code)
+If pre-commit hooks fail on fixable issues (ruff, trailing whitespace),
+fix and re-stage. Never `--no-verify` to skip fixable issues. The
+markdownlint config relaxes MD013/MD024/MD033/MD041 for this repo so
+CHANGELOG edits should pass cleanly.
+
+### 7. PR the release branch to `development`
+
+```bash
+gh pr create --base development --head release-<version> \
+  --title "release: <version> version bump + changelog (prepare for main)" \
+  --body "..."
+```
+
+Wait for CI (Tests x4: Python 3.11/3.12/3.13/3.14), then squash-merge.
+
+```bash
+gh pr merge <pr-number> --squash --delete-branch
+```
+
+This lands the version bump on `development`, satisfying the rule that
+`development` is always ahead of `main`.
+
+### 8. Open the actual release PR `development → main`
+
+```bash
+git checkout development && git pull
+gh pr create --base main --head development --title "release: <version>" --body "..."
+```
+
+The PR body should summarize what's shipping. Wait for CI (all four
+Test checks must pass — they're required by `main` branch protection).
+
+### 9. Merge to `main`
+
+```bash
+gh pr view <pr-number> --json mergeStateStatus  # must be CLEAN
+gh pr merge <pr-number> --merge  # preserves merge commit
+```
+
+Notes:
+
+- Use `--merge` (not `--squash`) so the merge commit is preserved on `main`
+- `enforce_admins: true` is set on `main`; the `--admin` flag is a no-op
+  but harmless. CI must be green; you cannot bypass
+
+The merge triggers `tag-release.yml`:
+
+1. **Create version tag** — reads `uv version --short`, tags `v<version>`
+2. **Build and deploy documentation** — GitHub Pages
+3. **Build and publish to PyPI** — `uv build` + `twine upload`
+
+### 10. Verify PyPI publish
+
+```bash
+gh run watch <tag-release-run-id> --exit-status
+
+curl -s https://pypi.org/pypi/testrail-api-module/json \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); \
+    print('latest:', d['info']['version'])"
+
+git fetch --tags --quiet
+git tag --sort=-version:refname | head -3
+```
+
+Confirm: PyPI shows the new version and `v<version>` tag exists locally.
+
+### 11. Create a GitHub release
+
+PyPI and tag are not enough — also create a GitHub release so it
+appears under <https://github.com/trtmn/testrail_api_module/releases>
+and Watchers get notified.
+
+```bash
+gh release create v<version> --title "v<version>" --notes "$(cat <<'EOF'
+## 🐛 Fixed
+- <items, with issue refs>
+
+## 🔧 Changed
+- <items>
+
+## 🔄 Maintenance
+- <items>
+
+## Install
+
+\`\`\`bash
+pip install testrail-api-module==<version>
+\`\`\`
+
+## Full changelog
+
+See [CHANGELOG.md](https://github.com/trtmn/testrail_api_module/blob/v<version>/CHANGELOG.md#<anchor>) and the [PyPI page](https://pypi.org/project/testrail-api-module/<version>/).
 EOF
 )"
 ```
 
-### 6. Wait for CI and merge
+Use the same category headings as `CHANGELOG.md` (🐛 Fixed, ✨ Added,
+🔧 Changed, 🚨 Breaking Changes, 🔄 Maintenance). The CHANGELOG anchor
+follows GitHub's convention: `#<version>---<yyyy-mm-dd>` (lowercase,
+hyphens, em-dash replaced with three hyphens).
 
-```bash
-# Watch CI checks (timeout 5 minutes)
-gh pr checks <pr-number> --watch
-
-# Merge after CI passes (use --admin to bypass review requirement)
-gh pr merge <pr-number> --admin --merge
-```
-
-Note: This repo does not allow squash merges. Always use `--merge`.
-
-### 7. Sync `development` with merge commit from `main`
-
-The merge to `main` creates a merge commit that only exists on `main`.
-Pull it back into `development` so the branches stay in sync.
-
-```bash
-git checkout development
-git fetch origin main
-git merge origin/main
-git push origin development
-```
-
-### 8. Confirm
+### 12. Confirm
 
 Report to the user:
 
-- PR URL
-- That the merge is complete
-- Tagging and PyPI publishing are handled automatically by
-  GitHub Actions after merge to `main`
+- PR URL (release PR)
+- Tag URL (`https://github.com/trtmn/testrail_api_module/releases/tag/v<version>`)
+- PyPI URL (`https://pypi.org/project/testrail-api-module/<version>/`)
+- GitHub release URL
+- That `development` and `main` are now in sync (the release PR
+  brought `development`'s state into `main`)
 
 ## Important Notes
 
-- GitHub Actions handles tagging and PyPI publishing automatically
-  after the PR is merged to `main` — do NOT manually create tags
-- You cannot re-publish the same version to PyPI — if a version was
-  already published, you must bump to a new version
-- Branch protection on `main` requires PRs; use `gh pr merge --admin`
-  to bypass the review requirement
-- Always use `--merge` (not `--squash`) when merging PRs
-- Feature branches should be merged into `development` first, then
-  `development` is merged into `main` for releases
+- **Never push directly to `main`.** `enforce_admins: true` blocks it
+  anyway; if it ever worked, you'd recreate the drift problem fixed in #107
+- **Never push directly to `development`.** Auto-mode classifier blocks it;
+  use a feature/release branch + PR
+- **Branch naming**: `release-<version>` (single dash). `release/<version>`
+  collides with the stale `release` branch
+- **CHANGELOG order**: newest version on top, under the `## [Unreleased]`
+  block if present, above the previous release block
+- **Cannot re-publish** the same version to PyPI — if a version was
+  already published, bump to a new one
+- **`tag-release.yml` runs on PR-close-to-`main`** with
+  `merged == true`. If the workflow doesn't run after a merge, check
+  that the PR's base was actually `main` (not `development`)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      uv:
+        patterns: ["*"]
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns: ["*"]
+    labels:
+      - "dependencies"
+      - "ci"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### 🔄 Maintenance
+
+- Bump transitive `Pygments` from 2.19.2 to 2.20.0 to resolve a low-severity
+  ReDoS advisory (CVE-2026-4539 / GHSA-5239-wwwm-4pmq). Pygments is
+  dev-only — pulled in by `pdoc`, `pytest`, and `rich` — so this does
+  not affect published-wheel users (#114).
+- Commit `.github/dependabot.yml` codifying the previously UI-only
+  Dependabot configuration: weekly updates for both the `uv` ecosystem
+  and `github-actions`, with both ecosystems grouped into a single PR
+  each (#114).
+
 ## [0.7.2] - 2026-05-22
 
 ### 🐛 Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.3] - 2026-05-22
 
 ### 🔄 Maintenance
 
 - Bump transitive `Pygments` from 2.19.2 to 2.20.0 to resolve a low-severity
   ReDoS advisory (CVE-2026-4539 / GHSA-5239-wwwm-4pmq). Pygments is
   dev-only — pulled in by `pdoc`, `pytest`, and `rich` — so this does
-  not affect published-wheel users (#114).
+  not affect published-wheel users (#114, #115).
 - Commit `.github/dependabot.yml` codifying the previously UI-only
   Dependabot configuration: weekly updates for both the `uv` ecosystem
   and `github-actions`, with both ecosystems grouped into a single PR
-  each (#114).
+  each (#114, #115).
+- Document the new release workflow in `.claude/skills/release/SKILL.md`:
+  pre-release drift check, local `tox` run, two-PR flow
+  (release-branch → development → main), PyPI verification, and
+  GitHub release creation (#113).
 
 ## [0.7.2] - 2026-05-22
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "testrail-api-module"
-version = "0.7.2"
+version = "0.7.3"
 description = "A comprehensive Python wrapper for the TestRail API with enhanced error handling and performance improvements"
 authors = [
     { name = "Matt Troutman", email = "github@trtmn.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -848,11 +848,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1062,7 +1062,7 @@ wheels = [
 
 [[package]]
 name = "testrail-api-module"
-version = "0.7.2"
+version = "0.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Release 0.7.3

Merging this PR triggers \`tag-release.yml\`: tag \`v0.7.3\`, deploy docs, publish to PyPI. After publish, I'll create the matching GitHub release.

### What's in 0.7.3 — all maintenance / no behavior changes

**🔄 Maintenance**

- **Pygments 2.19.2 → 2.20.0** — closes Dependabot alert #3 (CVE-2026-4539, GHSA-5239-wwwm-4pmq). Low-severity ReDoS in GUID matching. Pygments is dev-only (transitive via pdoc, pytest, rich) and not in the published wheel, so end-user impact is zero — but worth shipping clean. (#114, #115)
- **Commit \`.github/dependabot.yml\`** — Dependabot was running on UI settings; now the cadence and grouping (weekly uv + github-actions, both grouped into single PRs) are codified in the repo. Adds the github-actions ecosystem watcher, which will auto-open PRs to bump the Node-20-deprecated CI actions. (#114, #115)
- **Document the new release workflow** in \`.claude/skills/release/SKILL.md\` — drift check, local tox, two-PR flow, PyPI verification, GitHub release step. (#113)

### Verification

- [x] Drift check passed
- [x] \`uv run tox\` — all four Python versions pass (418 tests each)
- [x] \`[0.7.3] - 2026-05-22\` block in CHANGELOG
- [x] \`pyproject.toml\` version is \`0.7.3\`
- [ ] CI green on this PR (Tests x4)
- [ ] After merge: tag \`v0.7.3\` created, PyPI shows 0.7.3, GitHub release published

🤖 Generated with [Claude Code](https://claude.com/claude-code)