### PR TITLE
release: 0.7.4 version bump + changelog (prepare for main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.4] - 2026-05-22
+
+### 🔄 Maintenance
+
+- Bump GitHub Actions to drop Node.js 20 deprecation warnings on CI runs
+  (#116):
+  - `actions/checkout` 4 → 6
+  - `astral-sh/setup-uv` 4 → 7
+  - `actions/setup-python` 5 → 6
+  - `actions/configure-pages` 5 → 6
+  - `actions/upload-pages-artifact` 3 → 5
+  - `actions/deploy-pages` 4 → 5
+- Bump Python dependencies via Dependabot's uv group (#117). The
+  `requests` bump is to the runtime dep (the HTTP library that powers
+  `BaseAPI`); the rest are dev-only:
+  - `requests` 2.33.0 → 2.34.2 (runtime)
+  - `pytest-cov` 7.0.0 → 7.1.0
+  - `mypy` 1.19.1 → 2.1.0
+  - `pre-commit` 4.5.1 → 4.6.0
+  - `ruff` 0.14.11 → 0.15.14
+  - `bandit` 1.9.3 → 1.9.4
+
 ## [0.7.3] - 2026-05-22
 
 ### 🔄 Maintenance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "testrail-api-module"
-version = "0.7.3"
+version = "0.7.4"
 description = "A comprehensive Python wrapper for the TestRail API with enhanced error handling and performance improvements"
 authors = [
     { name = "Matt Troutman", email = "github@trtmn.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -1127,7 +1127,7 @@ wheels = [
 
 [[package]]
 name = "testrail-api-module"
-version = "0.7.3"
+version = "0.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Prepare release 0.7.4

Bumps `pyproject.toml` to `0.7.4` and adds a `[0.7.4] - 2026-05-22` block to CHANGELOG documenting the Dependabot updates that landed since 0.7.3 (#116, #117).

This is the prep PR onto `development`. The release PR `development → main` follows immediately after this merges.

### What's in 0.7.4 (all 🔄 Maintenance, no behavior change)

**GitHub Actions** (`#116`)
- `actions/checkout` 4→6, `astral-sh/setup-uv` 4→7, `actions/setup-python` 5→6, `actions/configure-pages` 5→6, `actions/upload-pages-artifact` 3→5, `actions/deploy-pages` 4→5
- These bumps drop the Node 20 deprecation warning we've been seeing on every CI run

**Python deps** (`#117`)
- `requests` 2.33.0 → 2.34.2 (runtime)
- `pytest-cov`, `mypy`, `pre-commit`, `ruff`, `bandit` (all dev)

### Verification

- [x] Drift check: no main-only content vs development
- [x] `uv run tox` — all four Python versions pass (418 tests each)
- [x] `uv version --short` reports `0.7.4`
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)