### PR TITLE
ci: auto-create GitHub release after PyPI publish

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -156,6 +156,8 @@ The merge triggers `tag-release.yml`:
 1. **Create version tag** — reads `uv version --short`, tags `v<version>`
 2. **Build and deploy documentation** — GitHub Pages
 3. **Build and publish to PyPI** — `uv build` + `twine upload`
+4. **Create GitHub release** — pulls notes from the `[<version>]` block
+   in `CHANGELOG.md` and runs `gh release create v<version>`
 
 ### 10. Verify PyPI publish
 
@@ -172,51 +174,37 @@ git tag --sort=-version:refname | head -3
 
 Confirm: PyPI shows the new version and `v<version>` tag exists locally.
 
-### 11. Create a GitHub release
+### 11. Confirm
 
-PyPI and tag are not enough — also create a GitHub release so it
-appears under <https://github.com/trtmn/testrail_api_module/releases>
-and Watchers get notified.
-
-```bash
-gh release create v<version> --title "v<version>" --notes "$(cat <<'EOF'
-## 🐛 Fixed
-- <items, with issue refs>
-
-## 🔧 Changed
-- <items>
-
-## 🔄 Maintenance
-- <items>
-
-## Install
-
-\`\`\`bash
-pip install testrail-api-module==<version>
-\`\`\`
-
-## Full changelog
-
-See [CHANGELOG.md](https://github.com/trtmn/testrail_api_module/blob/v<version>/CHANGELOG.md#<anchor>) and the [PyPI page](https://pypi.org/project/testrail-api-module/<version>/).
-EOF
-)"
-```
-
-Use the same category headings as `CHANGELOG.md` (🐛 Fixed, ✨ Added,
-🔧 Changed, 🚨 Breaking Changes, 🔄 Maintenance). The CHANGELOG anchor
-follows GitHub's convention: `#<version>---<yyyy-mm-dd>` (lowercase,
-hyphens, em-dash replaced with three hyphens).
-
-### 12. Confirm
+The `github-release` job in `tag-release.yml` creates the GitHub
+release automatically — it pulls notes from the matching `[<version>]`
+block in `CHANGELOG.md`, appends an install snippet, and runs
+`gh release create v<version>`. So once `tag-release.yml` is green
+you have a tag, PyPI artifact, deployed docs, **and** a GitHub
+release for free.
 
 Report to the user:
 
 - PR URL (release PR)
 - Tag URL (`https://github.com/trtmn/testrail_api_module/releases/tag/v<version>`)
 - PyPI URL (`https://pypi.org/project/testrail-api-module/<version>/`)
-- GitHub release URL
+- GitHub release URL (auto-created — same as the tag URL)
 - That `development` and `main` are now in sync (the release PR
   brought `development`'s state into `main`)
+
+If for any reason the workflow's `github-release` job failed and you
+need to create the release manually, the workflow's exact note
+generation can be reproduced locally:
+
+```bash
+version=<version>
+awk -v ver="$version" '
+  $0 ~ "^## \\[" ver "\\]" { flag=1; print; next }
+  flag && /^## \[/         { exit }
+  flag                     { print }
+' CHANGELOG.md > /tmp/notes.md
+gh release create "v$version" --title "v$version" --notes-file /tmp/notes.md
+```
 
 ## Important Notes
 

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -129,3 +129,51 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: twine upload dist/*
+
+  github-release:
+    name: Create GitHub release
+    needs: [tag, publish]
+    if: needs.tag.outputs.tag_exists == 'false'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code at the new tag
+        uses: actions/checkout@v6
+        with:
+          ref: v${{ needs.tag.outputs.version }}
+
+      - name: Extract release notes from CHANGELOG.md
+        env:
+          VERSION: ${{ needs.tag.outputs.version }}
+          REPO: ${{ github.repository }}
+        run: |
+          {
+            awk -v ver="$VERSION" '
+              $0 ~ "^## \\[" ver "\\]" { flag=1; print; next }
+              flag && /^## \[/         { exit }
+              flag                     { print }
+            ' CHANGELOG.md
+            echo ""
+            echo "## Install"
+            echo ""
+            echo '```bash'
+            echo "pip install testrail-api-module==$VERSION"
+            echo '```'
+            echo ""
+            echo "## Full changelog"
+            echo ""
+            echo "See [CHANGELOG.md](https://github.com/$REPO/blob/v$VERSION/CHANGELOG.md) and the [PyPI page](https://pypi.org/project/testrail-api-module/$VERSION/)."
+          } > /tmp/release_notes.md
+          echo "--- Generated release notes ---"
+          cat /tmp/release_notes.md
+
+      - name: Create GitHub release
+        env:
+          VERSION: ${{ needs.tag.outputs.version }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v$VERSION" \
+            --title "v$VERSION" \
+            --notes-file /tmp/release_notes.md \
+            --repo "$REPO"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### 🔄 Maintenance
+
+- Automate GitHub release creation in `tag-release.yml`. A new
+  `github-release` job runs after the PyPI publish, extracts the
+  matching `[<version>]` block from `CHANGELOG.md`, appends an install
+  snippet, and runs `gh release create`. Previously this was a manual
+  step in the release skill (step 11). Now every PyPI publish gets a
+  matching GitHub release for free. (#122)
+
 ## [0.7.4] - 2026-05-22
 
 ### 🔄 Maintenance


### PR DESCRIPTION
## Summary

Adds a new \`github-release\` job to \`tag-release.yml\` that runs after the existing \`publish\` job and creates the matching GitHub release automatically. Previously this was step 11 of the release skill — a manual \`gh release create\` after every PyPI publish.

Sources release notes from the matching \`## [<version>]\` block in \`CHANGELOG.md\` so what appears on GitHub matches what's documented.

Closes #122.

## Job structure

\`\`\`yaml
github-release:
  name: Create GitHub release
  needs: [tag, publish]
  if: needs.tag.outputs.tag_exists == 'false'
  runs-on: ubuntu-latest
  steps:
    - checkout at v<version>
    - extract CHANGELOG section + append install snippet
    - gh release create v<version> --notes-file ...
\`\`\`

## Security

All \`\${{ ... }}\` expansions that flow into shell commands are routed through \`env:\` per [GitHub's workflow-injection guidance](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/). The values used (\`needs.tag.outputs.version\`, \`github.repository\`, \`github.token\`) aren't attacker-controllable here, but the \`env:\` pattern is correct best practice.

## Verification

I tested the awk extractor locally against the current \`CHANGELOG.md\` for version \`0.7.4\` and it produces clean output matching the manually-created GitHub release for v0.7.4.

The next release (0.7.5+) will be the live test. The job is gated on \`tag_exists == 'false'\` so it won't try to recreate a release if one already exists.

## Test plan

- [x] Awk extractor produces correct notes locally
- [x] \`env:\` used for all shell-interpolated values (per security hook)
- [ ] PR CI green (workflow itself isn't exercised by PR — only by merge to main)
- [ ] Next release auto-creates a GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)