### PR TITLE
ci: set bootstrap-sha for release-please

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -7,6 +7,7 @@
   "bump-patch-for-minor-pre-major": true,
   "draft": false,
   "prerelease": false,
+  "bootstrap-sha": "902a6866519df109e860886c7a233bdb0209fd02",
   "packages": {
     ".": {
       "package-name": "testrail-api-module",

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -136,6 +136,15 @@
     }
   ],
   "results": {
+    ".github/release-please-config.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".github/release-please-config.json",
+        "hashed_secret": "482c060f6bf1bf0feb45564fcbe36540c88dd425",
+        "is_verified": false,
+        "line_number": 10
+      }
+    ],
     "MIGRATION_GUIDE.md": [
       {
         "type": "Secret Keyword",
@@ -180,5 +189,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-17T04:34:51Z"
+  "generated_at": "2026-05-22T23:22:58Z"
 }


### PR DESCRIPTION
## Why

release-please's first run on this repo scanned the entire commit history (56 commits) and opened PR #127 with stale pre-0.7.4 entries in its CHANGELOG body. Setting \`bootstrap-sha\` in \`.github/release-please-config.json\` to the commit pointed at by \`v0.7.4\` makes release-please ignore everything before that point — so only commits we actually want released get included.

SHA: \`902a686\` (the v0.7.4 commit).

Also bumps \`.secrets.baseline\` because the SHA's hex pattern triggered detect-secrets.

## What this fixes

After this merges:
1. release-please will re-run on \`development\`
2. It'll only consider commits since v0.7.4: this PR, the migration (#125), and this session's other work
3. It'll open a fresh \`chore(development): release X.Y.Z\` PR with a clean CHANGELOG body

Unblocks the migration from #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)