### PR TITLE
chore: add trove classifiers and fix author metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,25 @@ version = "0.7.6"
 description = "A comprehensive Python wrapper for the TestRail API with enhanced error handling and performance improvements"
 authors = [
     { name = "Matt Troutman", email = "github@trtmn.com" },
-    { name = "Christian Thompson", email = "example@example.com" }
+    { name = "Christian Thompson" },
+    { name = "Andrew Tipper" }
 ]
 requires-python = ">=3.11"
 license = "MIT"
 license-files = ["LICENSE"]
 readme = "README.md"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development :: Testing",
+    "Typing :: Typed",
+]
 dependencies = [
     "requests>=2.32.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1127,7 +1127,7 @@ wheels = [
 
 [[package]]
 name = "testrail-api-module"
-version = "0.7.4"
+version = "0.7.6"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Summary

Fixes the `[project]` metadata gaps found in the automated repo audit:

- **Trove classifiers added**: `Development Status :: 4 - Beta`, `Intended Audience :: Developers`, `Operating System :: OS Independent`, `Programming Language :: Python :: 3` / `3.11` / `3.12` / `3.13` / `3.14`, `Topic :: Software Development :: Testing`, `Typing :: Typed`. PyPI will now show supported-version chips.
- **`License :: OSI Approved :: MIT License` classifier intentionally omitted**: the project already uses the PEP 639 SPDX form (`license = "MIT"` + `license-files`), which emits `License-Expression: MIT` in core metadata. PEP 639 deprecates `License ::` classifiers alongside SPDX expressions, and newer setuptools rejects the combination — the SPDX expression is the authoritative license declaration.
- **Placeholder email removed**: "Christian Thompson" had `example@example.com` published in PyPI metadata; the entry is now name-only (valid per PEP 621).
- **Author lists reconciled**: README lists three authors; pyproject listed two. Added "Andrew Tipper" (name-only) to match.
- `uv.lock` version field synced from stale `0.7.4` to `0.7.6` as a side effect of `uv sync`.

Only the `[project]` table was touched — no `[tool.*]` tables modified (parallel PRs own those).

## Validation

- `uv sync --extra dev` — succeeds
- `uv build --out-dir /tmp/154-build` — succeeds; wheel METADATA verified to contain all 10 classifiers, `Author: Christian Thompson, Andrew Tipper`, `Author-email: Matt Troutman <github@trtmn.com>`, and `License-Expression: MIT`
- `uv run pytest -q` — 418 passed
- No artifacts left in the repo's `dist/`

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)
