### PR TITLE
fix: sections move_section null semantics and pagination params

### DIFF
--- a/src/testrail_api_module/sections.py
+++ b/src/testrail_api_module/sections.py
@@ -3,11 +3,24 @@ This module provides functionality for managing sections in TestRail.
 Sections are used to organize test cases into hierarchical structures.
 """
 
-from typing import Any
+from typing import Any, Final
 
 from .base import BaseAPI
 
 __all__ = ["SectionsAPI"]
+
+
+class _UnsetType:
+    """Sentinel type distinguishing omitted arguments from ``None``."""
+
+    def __repr__(self) -> str:
+        return "UNSET"
+
+
+#: Sentinel default for ``move_section`` arguments. Arguments left at
+#: ``UNSET`` are omitted from the request body entirely, while an
+#: explicit ``None`` is sent as JSON ``null``.
+UNSET: Final = _UnsetType()
 
 
 class SectionsAPI(BaseAPI):
@@ -35,32 +48,48 @@ class SectionsAPI(BaseAPI):
             >>> section = api.sections.get_section(123)
             >>> print(f"Section: {section['name']}")
         """
-        return self._get(f"get_section/{section_id}")
+        return self._get(f"get_section/{section_id}")  # type: ignore[return-value]
 
     def get_sections(
-        self, project_id: int, suite_id: int | None = None
-    ) -> list[dict[str, Any]]:
+        self,
+        project_id: int,
+        suite_id: int | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """
         Get all sections for a project and optionally a specific suite.
 
         Args:
             project_id: The ID of the project to get sections for.
             suite_id: Optional ID of the suite to get sections for.
+            limit: Optional limit on number of results to return
+                (TestRail returns up to 250 by default).
+            offset: Optional offset for pagination.
 
         Returns:
-            List of dictionaries containing section data.
+            On TestRail 6.7+ this endpoint returns a pagination
+            envelope ``{"offset": ..., "limit": ..., "size": ...,
+            "_links": ..., "sections": [...]}``; older TestRail
+            versions return a plain list of section dictionaries.
 
         Raises:
             TestRailAPIError: If the API request fails.
 
         Example:
-            >>> sections = api.sections.get_sections(project_id=1, suite_id=2)
-            >>> for section in sections:
+            >>> response = api.sections.get_sections(
+            ...     project_id=1, suite_id=2
+            ... )
+            >>> for section in response["sections"]:
             ...     print(f"Section: {section['name']}")
         """
         params = {}
         if suite_id is not None:
             params["suite_id"] = suite_id
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
 
         return self._get(f"get_sections/{project_id}", params=params)
 
@@ -97,7 +126,7 @@ class SectionsAPI(BaseAPI):
             ...     parent_id=5
             ... )
         """
-        data = {"name": name}
+        data: dict[str, Any] = {"name": name}
 
         # Add optional fields only if they are provided
         optional_fields = {
@@ -110,7 +139,7 @@ class SectionsAPI(BaseAPI):
             if value is not None:
                 data[field] = value
 
-        return self._post(f"add_section/{project_id}", data=data)
+        return self._post(f"add_section/{project_id}", data=data)  # type: ignore[return-value]
 
     def update_section(
         self,
@@ -153,25 +182,31 @@ class SectionsAPI(BaseAPI):
             if value is not None:
                 data[field] = value
 
-        return self._post(f"update_section/{section_id}", data=data)
+        return self._post(f"update_section/{section_id}", data=data)  # type: ignore[return-value]
 
     def move_section(
         self,
         section_id: int,
-        parent_id: int | None = None,
-        after_id: int | None = None,
+        parent_id: int | None | _UnsetType = UNSET,
+        after_id: int | None | _UnsetType = UNSET,
     ) -> dict[str, Any]:
         """
         Move a section to a different parent or position.
 
         Requires TestRail 6.5.2+.
 
+        Arguments left at their defaults are omitted from the request
+        body. Passing an explicit ``None`` sends a JSON ``null``, which
+        TestRail interprets as described below.
+
         Args:
             section_id: The ID of the section to move.
-            parent_id: Optional new parent section ID. Use None or
-                omit for top-level.
-            after_id: Optional ID of the section to place this
-                section after. Use None to place first.
+            parent_id: New parent section ID. Pass ``None`` explicitly
+                to move the section to the top level (sent as JSON
+                ``null``). Omit to leave the parent unspecified.
+            after_id: ID of the section to place this section after.
+                Pass ``None`` explicitly to place it first (sent as
+                JSON ``null``). Omit to leave the position unspecified.
 
         Returns:
             Dict containing the response data.
@@ -185,14 +220,18 @@ class SectionsAPI(BaseAPI):
             ...     parent_id=5,
             ...     after_id=8
             ... )
+            >>> # Move to top level, first position:
+            >>> api.sections.move_section(
+            ...     section_id=10, parent_id=None, after_id=None
+            ... )
         """
         data: dict[str, Any] = {}
-        if parent_id is not None:
+        if not isinstance(parent_id, _UnsetType):
             data["parent_id"] = parent_id
-        if after_id is not None:
+        if not isinstance(after_id, _UnsetType):
             data["after_id"] = after_id
 
-        return self._post(f"move_section/{section_id}", data=data)
+        return self._post(f"move_section/{section_id}", data=data)  # type: ignore[return-value]
 
     def delete_section(self, section_id: int) -> dict[str, Any]:
         """
@@ -210,4 +249,4 @@ class SectionsAPI(BaseAPI):
         Example:
             >>> result = api.sections.delete_section(123)
         """
-        return self._post(f"delete_section/{section_id}")
+        return self._post(f"delete_section/{section_id}")  # type: ignore[return-value]

--- a/src/testrail_api_module/sections.pyi
+++ b/src/testrail_api_module/sections.pyi
@@ -1,8 +1,15 @@
-from typing import Any
+from typing import Any, Final
 
 from .base import BaseAPI
 
 __all__ = ["SectionsAPI"]
+
+class _UnsetType:
+    """Sentinel type distinguishing omitted arguments from ``None``."""
+
+    def __repr__(self) -> str: ...
+
+UNSET: Final[_UnsetType]
 
 class SectionsAPI(BaseAPI):
     """
@@ -29,24 +36,36 @@ class SectionsAPI(BaseAPI):
             >>> print(f"Section: {section[\'name\']}")
         """
     def get_sections(
-        self, project_id: int, suite_id: int | None = None
-    ) -> list[dict[str, Any]]:
+        self,
+        project_id: int,
+        suite_id: int | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """
         Get all sections for a project and optionally a specific suite.
 
         Args:
             project_id: The ID of the project to get sections for.
             suite_id: Optional ID of the suite to get sections for.
+            limit: Optional limit on number of results to return
+                (TestRail returns up to 250 by default).
+            offset: Optional offset for pagination.
 
         Returns:
-            List of dictionaries containing section data.
+            On TestRail 6.7+ this endpoint returns a pagination
+            envelope ``{"offset": ..., "limit": ..., "size": ...,
+            "_links": ..., "sections": [...]}``; older TestRail
+            versions return a plain list of section dictionaries.
 
         Raises:
             TestRailAPIError: If the API request fails.
 
         Example:
-            >>> sections = api.sections.get_sections(project_id=1, suite_id=2)
-            >>> for section in sections:
+            >>> response = api.sections.get_sections(
+            ...     project_id=1, suite_id=2
+            ... )
+            >>> for section in response["sections"]:
             ...     print(f"Section: {section[\'name\']}")
         """
     def add_section(
@@ -113,10 +132,17 @@ class SectionsAPI(BaseAPI):
     def move_section(
         self,
         section_id: int,
-        parent_id: int | None = None,
-        after_id: int | None = None,
+        parent_id: int | None | _UnsetType = ...,
+        after_id: int | None | _UnsetType = ...,
     ) -> dict[str, Any]:
-        """Move a section to a different parent or position. Requires TestRail 6.5.2+."""
+        """
+        Move a section to a different parent or position.
+
+        Requires TestRail 6.5.2+. Arguments left at their defaults are
+        omitted from the request body; an explicit ``None`` is sent as
+        JSON ``null`` (``parent_id=None`` moves to top level,
+        ``after_id=None`` places the section first).
+        """
     def delete_section(self, section_id: int) -> dict[str, Any]:
         """
         Delete a section.

--- a/tests/test_sections.py
+++ b/tests/test_sections.py
@@ -81,6 +81,56 @@ class TestSectionsAPI:
                 "get_sections/1", params=expected_params
             )
 
+    def test_get_sections_with_all_parameters(
+        self, sections_api: SectionsAPI
+    ) -> None:
+        """Test get_sections with all optional parameters."""
+        with patch.object(sections_api, "_get") as mock_get:
+            mock_get.return_value = [{"id": 1, "name": "Section 1"}]
+
+            result = sections_api.get_sections(
+                project_id=1, suite_id=2, limit=50, offset=100
+            )
+
+            expected_params = {"suite_id": 2, "limit": 50, "offset": 100}
+            mock_get.assert_called_once_with(
+                "get_sections/1", params=expected_params
+            )
+            assert result == [{"id": 1, "name": "Section 1"}]
+
+    def test_get_sections_with_none_values(
+        self, sections_api: SectionsAPI
+    ) -> None:
+        """Test get_sections with None values for optional parameters."""
+        with patch.object(sections_api, "_get") as mock_get:
+            mock_get.return_value = [{"id": 1, "name": "Section 1"}]
+
+            result = sections_api.get_sections(
+                project_id=1, suite_id=None, limit=None, offset=None
+            )
+
+            mock_get.assert_called_once_with("get_sections/1", params={})
+            assert result == [{"id": 1, "name": "Section 1"}]
+
+    def test_get_sections_pagination_envelope(
+        self, sections_api: SectionsAPI
+    ) -> None:
+        """Test get_sections returns the TestRail 6.7+ envelope as-is."""
+        with patch.object(sections_api, "_get") as mock_get:
+            envelope = {
+                "offset": 0,
+                "limit": 250,
+                "size": 1,
+                "_links": {"next": None, "prev": None},
+                "sections": [{"id": 1, "name": "Section 1"}],
+            }
+            mock_get.return_value = envelope
+
+            result = sections_api.get_sections(project_id=1)
+
+            mock_get.assert_called_once_with("get_sections/1", params={})
+            assert result == envelope
+
     def test_add_section_minimal(self, sections_api: SectionsAPI) -> None:
         """Test add_section with minimal required parameters."""
         with patch.object(sections_api, "_post") as mock_post:
@@ -190,6 +240,118 @@ class TestSectionsAPI:
             mock_post.assert_called_once_with(
                 "update_section/1", data=expected_data
             )
+
+    def test_move_section_minimal(self, sections_api: SectionsAPI) -> None:
+        """Test move_section with minimal required parameters."""
+        with patch.object(sections_api, "_post") as mock_post:
+            mock_post.return_value = {"id": 10, "parent_id": 5}
+
+            result = sections_api.move_section(section_id=10)
+
+            mock_post.assert_called_once_with("move_section/10", data={})
+            assert result == {"id": 10, "parent_id": 5}
+
+    def test_move_section_with_all_parameters(
+        self, sections_api: SectionsAPI
+    ) -> None:
+        """Test move_section with all optional parameters."""
+        with patch.object(sections_api, "_post") as mock_post:
+            mock_post.return_value = {"id": 10, "parent_id": 5}
+
+            result = sections_api.move_section(
+                section_id=10, parent_id=5, after_id=8
+            )
+
+            expected_data = {"parent_id": 5, "after_id": 8}
+            mock_post.assert_called_once_with(
+                "move_section/10", data=expected_data
+            )
+            assert result == {"id": 10, "parent_id": 5}
+
+    def test_move_section_with_none_values(
+        self, sections_api: SectionsAPI
+    ) -> None:
+        """Test move_section sends explicit None values as JSON null."""
+        with patch.object(sections_api, "_post") as mock_post:
+            mock_post.return_value = {"id": 10, "parent_id": None}
+
+            result = sections_api.move_section(
+                section_id=10, parent_id=None, after_id=None
+            )
+
+            expected_data = {"parent_id": None, "after_id": None}
+            mock_post.assert_called_once_with(
+                "move_section/10", data=expected_data
+            )
+            assert result == {"id": 10, "parent_id": None}
+
+    def test_move_section_with_parent_id_only(
+        self, sections_api: SectionsAPI
+    ) -> None:
+        """Test move_section omits after_id when not provided."""
+        with patch.object(sections_api, "_post") as mock_post:
+            mock_post.return_value = {"id": 10, "parent_id": 5}
+
+            result = sections_api.move_section(section_id=10, parent_id=5)
+
+            expected_data = {"parent_id": 5}
+            mock_post.assert_called_once_with(
+                "move_section/10", data=expected_data
+            )
+            assert result == {"id": 10, "parent_id": 5}
+
+    def test_move_section_with_after_id_none_only(
+        self, sections_api: SectionsAPI
+    ) -> None:
+        """Test move_section sends only an explicit null after_id."""
+        with patch.object(sections_api, "_post") as mock_post:
+            mock_post.return_value = {"id": 10, "parent_id": 5}
+
+            result = sections_api.move_section(section_id=10, after_id=None)
+
+            expected_data = {"after_id": None}
+            mock_post.assert_called_once_with(
+                "move_section/10", data=expected_data
+            )
+            assert result == {"id": 10, "parent_id": 5}
+
+    def test_move_section_api_request_failure(
+        self, sections_api: SectionsAPI
+    ) -> None:
+        """Test move_section behavior when API request fails."""
+        with patch.object(sections_api, "_post") as mock_post:
+            mock_post.side_effect = TestRailAPIError("API request failed")
+
+            with pytest.raises(TestRailAPIError, match="API request failed"):
+                sections_api.move_section(section_id=10, parent_id=5)
+
+    def test_move_section_authentication_error(
+        self, sections_api: SectionsAPI
+    ) -> None:
+        """Test move_section behavior when authentication fails."""
+        with patch.object(sections_api, "_post") as mock_post:
+            mock_post.side_effect = TestRailAuthenticationError(
+                "Authentication failed"
+            )
+
+            with pytest.raises(
+                TestRailAuthenticationError, match="Authentication failed"
+            ):
+                sections_api.move_section(section_id=10, parent_id=5)
+
+    def test_move_section_rate_limit_error(
+        self, sections_api: SectionsAPI
+    ) -> None:
+        """Test move_section behavior when rate limit is exceeded."""
+        with patch.object(sections_api, "_post") as mock_post:
+            mock_post.side_effect = TestRailRateLimitError(
+                "Rate limit exceeded"
+            )
+
+            with pytest.raises(
+                TestRailRateLimitError, match="Rate limit exceeded"
+            ):
+                sections_api.move_section(section_id=10, parent_id=5)
 
     def test_delete_section(self, sections_api: SectionsAPI) -> None:
         """Test delete_section method."""


### PR DESCRIPTION
## Summary

Fixes the three problems in `src/testrail_api_module/sections.py` reported in #145.

### 1. `move_section` can now send documented JSON `null` semantics

The docstring promised "Use None for top-level / to place first", but `None` values were filtered out of the body, so an explicit JSON `null` could never be sent and `move_section(10)` posted `{}`.

**Verification of null semantics** (direct fetch of support.testrail.com 403s; verified via three corroborating sources):
- The official docs (mirrored verbatim in the widely used `tolstislon/testrail-api` wrapper docstrings) state `parent_id` "can be null if it should be moved to the root" and `after_id` "The section ID after which the section should be put (can be null)".
- This repo's own community OpenAPI spec (`openapi/testrail.yaml`, #104) marks both fields `nullable: true` ("null for top level" / "null for first").
- That same third-party wrapper unconditionally sends both keys (including `null`) and works in production, confirming TestRail accepts explicit nulls.

Since null is meaningful, this PR introduces a module-level `UNSET` sentinel (`_UnsetType`) as the default for `parent_id`/`after_id`:
- **Omitted argument** → key excluded from the request body (same as before)
- **Explicit `None`** → key sent as JSON `null` (`parent_id=None` = move to top level, `after_id=None` = place first)
- Call signature stays backward-compatible; only the previously broken `None` path changes behavior (it used to silently drop the key).

`BaseAPI._api_request` sends `data` via `requests`' `json=` parameter, so `None` values serialize as JSON `null` (verified in `base.py`).

### 2. `get_sections` pagination params

Added documented `limit`/`offset` query params, following the existing pattern in `runs.py`/`cases.py` (only added to params when not `None`).

### 3. Pagination envelope annotation

`get_sections` was annotated `list[dict[str, Any]]`; on TestRail 6.7+ the endpoint actually returns the envelope `{"offset": ..., "limit": ..., "size": ..., "_links": ..., "sections": [...]}`. Updated the return annotation to `list[dict[str, Any]] | dict[str, Any]` and documented the envelope in the docstring and `.pyi` stub. No runtime change.

### Also
- Added `# type: ignore[return-value]` comments and a `data: dict[str, Any]` annotation matching the established `cases.py` pattern — required by the pre-commit mypy hook, which type-checks files individually against the `base.pyi` stub (these were latent and surfaced once the file was touched).
- Scope deliberately excludes transport-style migration (#156), stub `__all__` (#155), and CHANGELOG.md (release-please).

## Test plan

- [x] `move_section`: minimal (posts `{}`), all params, explicit `None` → `{"parent_id": None, "after_id": None}`, partial (`parent_id` only / `after_id=None` only), and APIError/AuthError/RateLimitError trio — all assert both call args and return value
- [x] `get_sections`: all-params (`suite_id`/`limit`/`offset`), None values filtered, 6.7+ envelope passed through as-is
- [x] `uv run pytest -q` — 429 passed
- [x] `uv run mypy src/` — no issues in 26 source files
- [x] `uv run ruff format` (touched files) + `uv run ruff check src/ tests/` — clean
- [x] pre-commit hooks (ruff, ruff-format, mypy, bandit, detect-secrets) — passed on commit

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)