### PR TITLE
fix!: correct transport layer (param serialization, retries, 2xx, sessions) and rewrite attachments/BDD file transfer

### DIFF
--- a/src/testrail_api_module/__init__.py
+++ b/src/testrail_api_module/__init__.py
@@ -17,12 +17,40 @@ Attributes:
 """
 
 import os
+from typing import Self
 
+from . import (
+    attachments,
+    bdd,
+    cases,
+    configurations,
+    datasets,
+    groups,
+    labels,
+    milestones,
+    plans,
+    priorities,
+    projects,
+    reports,
+    result_fields,
+    results,
+    roles,
+    runs,
+    sections,
+    shared_steps,
+    statuses,
+    suites,
+    templates,
+    tests,
+    users,
+    variables,
+)
 from .base import (
     TestRailAPIError,
     TestRailAPIException,
     TestRailAuthenticationError,
     TestRailRateLimitError,
+    _create_session,
 )
 
 
@@ -74,8 +102,10 @@ __version__ = _get_version()
 """The version of the module, used for compatibility checks and logging."""
 __author__ = "Matt Troutman, Christian Thompson, Andrew Tipper"
 
-# Update the docstring with the current version
-__doc__ = __doc__.format(version=__version__)
+# Update the docstring with the current version. Under `python -OO`
+# docstrings are stripped and __doc__ is None, so guard the format call.
+if __doc__:
+    __doc__ = __doc__.format(version=__version__)
 
 
 class TestRailAPI:
@@ -130,33 +160,8 @@ class TestRailAPI:
         self.timeout = timeout
         """Request timeout in seconds."""
 
-        # Initialize all submodules
-        from . import (
-            attachments,
-            bdd,
-            cases,
-            configurations,
-            datasets,
-            groups,
-            labels,
-            milestones,
-            plans,
-            priorities,
-            projects,
-            reports,
-            result_fields,
-            results,
-            roles,
-            runs,
-            sections,
-            shared_steps,
-            statuses,
-            suites,
-            templates,
-            tests,
-            users,
-            variables,
-        )
+        self.session = _create_session()
+        """Shared requests.Session used by all submodule APIs."""
 
         # Create instances of each submodule
         self.attachments = attachments.AttachmentsAPI(self)
@@ -230,6 +235,21 @@ class TestRailAPI:
 
         self.variables = variables.VariablesAPI(self)
         """API for managing variables in TestRail. See [VariablesAPI](testrail_api_module/variables.html) for details."""
+
+    def close(self) -> None:
+        """
+        Close the shared HTTP session and release its connection
+        pools. The client should not be used after calling this.
+        """
+        self.session.close()
+
+    def __enter__(self) -> Self:
+        """Enter the runtime context (returns the client itself)."""
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        """Exit the runtime context, closing the shared session."""
+        self.close()
 
 
 # Import exception classes for easy access

--- a/src/testrail_api_module/__init__.pyi
+++ b/src/testrail_api_module/__init__.pyi
@@ -1,9 +1,62 @@
-from typing import Any
+from typing import Self
 
+import requests
+
+from . import attachments as attachments
+from . import bdd as bdd
+from . import cases as cases
+from . import configurations as configurations
+from . import datasets as datasets
+from . import groups as groups
+from . import labels as labels
+from . import milestones as milestones
+from . import plans as plans
+from . import priorities as priorities
+from . import projects as projects
+from . import reports as reports
+from . import result_fields as result_fields
+from . import results as results
+from . import roles as roles
+from . import runs as runs
+from . import sections as sections
+from . import shared_steps as shared_steps
+from . import statuses as statuses
+from . import suites as suites
+from . import templates as templates
+from . import tests as tests
+from . import users as users
+from . import variables as variables
+from .attachments import AttachmentsAPI
 from .base import TestRailAPIError as TestRailAPIError
 from .base import TestRailAPIException as TestRailAPIException
 from .base import TestRailAuthenticationError as TestRailAuthenticationError
 from .base import TestRailRateLimitError as TestRailRateLimitError
+from .bdd import BDDAPI
+from .cases import CasesAPI
+from .configurations import ConfigurationsAPI
+from .datasets import DatasetsAPI
+from .groups import GroupsAPI
+from .labels import LabelsAPI
+from .milestones import MilestonesAPI
+from .plans import PlansAPI
+from .priorities import PrioritiesAPI
+from .projects import ProjectsAPI
+from .reports import ReportsAPI
+from .result_fields import ResultFieldsAPI
+from .results import ResultsAPI
+from .roles import RolesAPI
+from .runs import RunsAPI
+from .sections import SectionsAPI
+from .shared_steps import SharedStepsAPI
+from .statuses import StatusesAPI
+from .suites import SuitesAPI
+from .templates import TemplatesAPI
+from .tests import TestsAPI
+from .users import UsersAPI
+from .variables import VariablesAPI
+
+__version__: str
+__author__: str
 
 __all__ = [
     "TestRailAPI",
@@ -11,6 +64,30 @@ __all__ = [
     "TestRailAuthenticationError",
     "TestRailRateLimitError",
     "TestRailAPIException",
+    "attachments",
+    "bdd",
+    "cases",
+    "configurations",
+    "datasets",
+    "groups",
+    "labels",
+    "milestones",
+    "plans",
+    "priorities",
+    "projects",
+    "reports",
+    "result_fields",
+    "results",
+    "roles",
+    "runs",
+    "sections",
+    "shared_steps",
+    "statuses",
+    "suites",
+    "templates",
+    "tests",
+    "users",
+    "variables",
 ]
 
 class TestRailAPI:
@@ -19,35 +96,36 @@ class TestRailAPI:
     This class serves as the entry point for all TestRail API functionality.
     """
 
-    base_url: Any
-    username: Any
-    api_key: Any
-    password: Any
-    timeout: Any
-    attachments: Any
-    bdd: Any
-    cases: Any
-    configurations: Any
-    datasets: Any
-    groups: Any
-    labels: Any
-    milestones: Any
-    plans: Any
-    priorities: Any
-    projects: Any
-    reports: Any
-    result_fields: Any
-    results: Any
-    roles: Any
-    runs: Any
-    sections: Any
-    shared_steps: Any
-    statuses: Any
-    suites: Any
-    templates: Any
-    tests: Any
-    users: Any
-    variables: Any
+    base_url: str
+    username: str
+    api_key: str | None
+    password: str | None
+    timeout: int
+    session: requests.Session
+    attachments: AttachmentsAPI
+    bdd: BDDAPI
+    cases: CasesAPI
+    configurations: ConfigurationsAPI
+    datasets: DatasetsAPI
+    groups: GroupsAPI
+    labels: LabelsAPI
+    milestones: MilestonesAPI
+    plans: PlansAPI
+    priorities: PrioritiesAPI
+    projects: ProjectsAPI
+    reports: ReportsAPI
+    result_fields: ResultFieldsAPI
+    results: ResultsAPI
+    roles: RolesAPI
+    runs: RunsAPI
+    sections: SectionsAPI
+    shared_steps: SharedStepsAPI
+    statuses: StatusesAPI
+    suites: SuitesAPI
+    templates: TemplatesAPI
+    tests: TestsAPI
+    users: UsersAPI
+    variables: VariablesAPI
     def __init__(
         self,
         base_url: str,
@@ -70,3 +148,7 @@ class TestRailAPI:
             ValueError: If neither api_key nor password is provided.
             ValueError: If base_url is not a valid URL format.
         """
+    def close(self) -> None:
+        """Close the shared HTTP session and its connection pools."""
+    def __enter__(self) -> Self: ...
+    def __exit__(self, *exc_info: object) -> None: ...

--- a/src/testrail_api_module/attachments.py
+++ b/src/testrail_api_module/attachments.py
@@ -1,6 +1,11 @@
 """
 This module provides functionality for managing attachments in TestRail.
-Attachments can be added to test cases, test runs, and other entities.
+Attachments can be added to test cases, test plans, test plan entries,
+test results, and test runs, and retrieved for cases, plans, plan
+entries, runs, and tests.
+
+Uploads are sent as ``multipart/form-data`` with the file bytes in an
+``attachment`` form field, matching the official TestRail API contract.
 """
 
 from typing import Any
@@ -15,89 +20,277 @@ class AttachmentsAPI(BaseAPI):
     API for managing TestRail attachments.
 
     This class provides methods to add, retrieve, and delete file
-    attachments on test cases, runs, plans, and other TestRail entities.
+    attachments on test cases, plans, plan entries, results, and runs.
     """
 
-    def get_attachment(self, attachment_id: int) -> dict[str, Any]:
+    def add_attachment_to_case(
+        self, case_id: int, file_path: str
+    ) -> dict[str, Any]:
         """
-        Get an attachment by ID.
+        Add an attachment to a test case.
+
+        Args:
+            case_id: The ID of the test case.
+            file_path: The path to the file to attach.
+
+        Returns:
+            Dict containing the created attachment ID, e.g.
+            ``{"attachment_id": 443}``.
+
+        Raises:
+            FileNotFoundError: If the file does not exist.
+            TestRailAPIError: If the API request fails.
+        """
+        return self._post_multipart(
+            f"add_attachment_to_case/{case_id}", file_path
+        )
+
+    def add_attachment_to_plan(
+        self, plan_id: int, file_path: str
+    ) -> dict[str, Any]:
+        """
+        Add an attachment to a test plan.
+
+        Args:
+            plan_id: The ID of the test plan.
+            file_path: The path to the file to attach.
+
+        Returns:
+            Dict containing the created attachment ID, e.g.
+            ``{"attachment_id": 443}``.
+
+        Raises:
+            FileNotFoundError: If the file does not exist.
+            TestRailAPIError: If the API request fails.
+        """
+        return self._post_multipart(
+            f"add_attachment_to_plan/{plan_id}", file_path
+        )
+
+    def add_attachment_to_plan_entry(
+        self, plan_id: int, entry_id: int, file_path: str
+    ) -> dict[str, Any]:
+        """
+        Add an attachment to a test plan entry.
+
+        Args:
+            plan_id: The ID of the test plan containing the entry.
+            entry_id: The ID of the test plan entry.
+            file_path: The path to the file to attach.
+
+        Returns:
+            Dict containing the created attachment ID, e.g.
+            ``{"attachment_id": 443}``.
+
+        Raises:
+            FileNotFoundError: If the file does not exist.
+            TestRailAPIError: If the API request fails.
+        """
+        return self._post_multipart(
+            f"add_attachment_to_plan_entry/{plan_id}/{entry_id}",
+            file_path,
+        )
+
+    def add_attachment_to_result(
+        self, result_id: int, file_path: str
+    ) -> dict[str, Any]:
+        """
+        Add an attachment to a test result.
+
+        Args:
+            result_id: The ID of the test result.
+            file_path: The path to the file to attach.
+
+        Returns:
+            Dict containing the created attachment ID, e.g.
+            ``{"attachment_id": 443}``.
+
+        Raises:
+            FileNotFoundError: If the file does not exist.
+            TestRailAPIError: If the API request fails.
+        """
+        return self._post_multipart(
+            f"add_attachment_to_result/{result_id}", file_path
+        )
+
+    def add_attachment_to_run(
+        self, run_id: int, file_path: str
+    ) -> dict[str, Any]:
+        """
+        Add an attachment to a test run.
+
+        Args:
+            run_id: The ID of the test run.
+            file_path: The path to the file to attach.
+
+        Returns:
+            Dict containing the created attachment ID, e.g.
+            ``{"attachment_id": 443}``.
+
+        Raises:
+            FileNotFoundError: If the file does not exist.
+            TestRailAPIError: If the API request fails.
+        """
+        return self._post_multipart(
+            f"add_attachment_to_run/{run_id}", file_path
+        )
+
+    def get_attachments_for_case(
+        self,
+        case_id: int,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        """
+        Get all attachments for a test case.
+
+        Args:
+            case_id: The ID of the test case.
+            limit: The number of attachments to return (max 250).
+            offset: The offset to start returning attachments from.
+
+        Returns:
+            Attachment data (paginated dict on TestRail 6.7+, plain
+            list on older versions).
+
+        Raises:
+            TestRailAPIError: If the API request fails.
+        """
+        params: dict[str, Any] = {}
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        return self._get(f"get_attachments_for_case/{case_id}", params=params)
+
+    def get_attachments_for_plan(
+        self,
+        plan_id: int,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        """
+        Get all attachments for a test plan.
+
+        Args:
+            plan_id: The ID of the test plan.
+            limit: The number of attachments to return (max 250).
+            offset: The offset to start returning attachments from.
+
+        Returns:
+            Attachment data (paginated dict on TestRail 6.7+, plain
+            list on older versions).
+
+        Raises:
+            TestRailAPIError: If the API request fails.
+        """
+        params: dict[str, Any] = {}
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        return self._get(f"get_attachments_for_plan/{plan_id}", params=params)
+
+    def get_attachments_for_plan_entry(
+        self, plan_id: int, entry_id: int
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        """
+        Get all attachments for a test plan entry.
+
+        Args:
+            plan_id: The ID of the test plan containing the entry.
+            entry_id: The ID of the test plan entry.
+
+        Returns:
+            Attachment data (paginated dict on TestRail 6.7+, plain
+            list on older versions).
+
+        Raises:
+            TestRailAPIError: If the API request fails.
+        """
+        return self._get(
+            f"get_attachments_for_plan_entry/{plan_id}/{entry_id}"
+        )
+
+    def get_attachments_for_run(
+        self,
+        run_id: int,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        """
+        Get all attachments for a test run.
+
+        Args:
+            run_id: The ID of the test run.
+            limit: The number of attachments to return (max 250).
+            offset: The offset to start returning attachments from.
+
+        Returns:
+            Attachment data (paginated dict on TestRail 6.7+, plain
+            list on older versions).
+
+        Raises:
+            TestRailAPIError: If the API request fails.
+        """
+        params: dict[str, Any] = {}
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        return self._get(f"get_attachments_for_run/{run_id}", params=params)
+
+    def get_attachments_for_test(
+        self, test_id: int
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        """
+        Get all attachments for a test.
+
+        Args:
+            test_id: The ID of the test.
+
+        Returns:
+            Attachment data (paginated dict on TestRail 6.7+, plain
+            list on older versions).
+
+        Raises:
+            TestRailAPIError: If the API request fails.
+        """
+        return self._get(f"get_attachments_for_test/{test_id}")
+
+    def get_attachment(self, attachment_id: int | str) -> bytes:
+        """
+        Download an attachment by ID.
 
         Args:
             attachment_id: The ID of the attachment to retrieve.
+                Newer TestRail versions use UUID strings, older ones
+                use integers.
 
         Returns:
-            Dict containing the attachment data.
+            The raw file content as bytes.
 
         Raises:
             TestRailAPIError: If the API request fails.
         """
-        return self._api_request("GET", f"get_attachment/{attachment_id}")
+        return self._get(f"get_attachment/{attachment_id}", raw=True)
 
-    def get_attachments(
-        self, entity_type: str, entity_id: int
-    ) -> list[dict[str, Any]]:
-        """
-        Get all attachments for a specific entity.
-
-        Args:
-            entity_type: The type of entity
-                ('case', 'run', 'plan', 'project').
-            entity_id: The ID of the entity to get attachments for.
-
-        Returns:
-            List of dictionaries containing attachment data.
-
-        Raises:
-            TestRailAPIError: If the API request fails.
-        """
-        return self._api_request(
-            "GET", f"get_attachments/{entity_type}/{entity_id}"
-        )
-
-    def add_attachment(
-        self,
-        entity_type: str,
-        entity_id: int,
-        file_path: str,
-        description: str | None = None,
-    ) -> dict[str, Any]:
-        """
-        Add an attachment to a specific entity.
-
-        Args:
-            entity_type: The type of entity
-                ('case', 'run', 'plan', 'project').
-            entity_id: The ID of the entity to add the attachment to.
-            file_path: The path to the file to attach.
-            description: Optional description of the attachment.
-
-        Returns:
-            Dict containing the created attachment data.
-
-        Raises:
-            TestRailAPIError: If the API request fails.
-        """
-        data = {"file": file_path}
-        if description:
-            data["description"] = description
-
-        return self._api_request(
-            "POST",
-            f"add_attachment/{entity_type}/{entity_id}",
-            data=data,
-        )
-
-    def delete_attachment(self, attachment_id: int) -> dict[str, Any]:
+    def delete_attachment(self, attachment_id: int | str) -> dict[str, Any]:
         """
         Delete an attachment.
 
         Args:
             attachment_id: The ID of the attachment to delete.
+                Newer TestRail versions use UUID strings, older ones
+                use integers.
 
         Returns:
-            Dict containing the response data.
+            Empty dict on success (TestRail returns an empty body).
 
         Raises:
             TestRailAPIError: If the API request fails.
         """
-        return self._api_request("POST", f"delete_attachment/{attachment_id}")
+        return self._post(f"delete_attachment/{attachment_id}")

--- a/src/testrail_api_module/attachments.pyi
+++ b/src/testrail_api_module/attachments.pyi
@@ -3,15 +3,46 @@ from typing import Any
 from .base import BaseAPI as BaseAPI
 
 class AttachmentsAPI(BaseAPI):
-    def get_attachment(self, attachment_id: int) -> dict[str, Any]: ...
-    def get_attachments(
-        self, entity_type: str, entity_id: int
-    ) -> list[dict[str, Any]]: ...
-    def add_attachment(
-        self,
-        entity_type: str,
-        entity_id: int,
-        file_path: str,
-        description: str | None = None,
+    def add_attachment_to_case(
+        self, case_id: int, file_path: str
     ) -> dict[str, Any]: ...
-    def delete_attachment(self, attachment_id: int) -> dict[str, Any]: ...
+    def add_attachment_to_plan(
+        self, plan_id: int, file_path: str
+    ) -> dict[str, Any]: ...
+    def add_attachment_to_plan_entry(
+        self, plan_id: int, entry_id: int, file_path: str
+    ) -> dict[str, Any]: ...
+    def add_attachment_to_result(
+        self, result_id: int, file_path: str
+    ) -> dict[str, Any]: ...
+    def add_attachment_to_run(
+        self, run_id: int, file_path: str
+    ) -> dict[str, Any]: ...
+    def get_attachments_for_case(
+        self,
+        case_id: int,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> dict[str, Any] | list[dict[str, Any]]: ...
+    def get_attachments_for_plan(
+        self,
+        plan_id: int,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> dict[str, Any] | list[dict[str, Any]]: ...
+    def get_attachments_for_plan_entry(
+        self, plan_id: int, entry_id: int
+    ) -> dict[str, Any] | list[dict[str, Any]]: ...
+    def get_attachments_for_run(
+        self,
+        run_id: int,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> dict[str, Any] | list[dict[str, Any]]: ...
+    def get_attachments_for_test(
+        self, test_id: int
+    ) -> dict[str, Any] | list[dict[str, Any]]: ...
+    def get_attachment(self, attachment_id: int | str) -> bytes: ...
+    def delete_attachment(
+        self, attachment_id: int | str
+    ) -> dict[str, Any]: ...

--- a/src/testrail_api_module/base.py
+++ b/src/testrail_api_module/base.py
@@ -54,6 +54,85 @@ class TestRailAPIException(TestRailAPIError):
         self.response_text = response_text
 
 
+class _TestRailRetry(Retry):
+    """
+    Retry policy tailored to the TestRail API.
+
+    TestRail performs *all* write operations (including deletes) via
+    POST, and those writes are not idempotent. Replaying a POST whose
+    request may already have reached the server could duplicate data,
+    so POSTs are only retried when it is safe to do so:
+
+    - 429 responses (the server refused the request without acting
+      on it)
+    - connection errors (the request never reached the server)
+
+    All other methods (reads) retry on connection errors, read errors,
+    and the configured ``status_forcelist`` (429/5xx).
+    """
+
+    def _is_method_retryable(self, method: str) -> bool:
+        # Gates read-error retries: a read error means the request may
+        # have been received by the server, so never replay a POST.
+        if method.upper() == "POST":
+            return False
+        return super()._is_method_retryable(method)
+
+    def is_retry(
+        self, method: str, status_code: int, has_retry_after: bool = False
+    ) -> bool:
+        # Gates status-based retries: POSTs are only safe to retry on
+        # 429, where the server rejected the request without acting.
+        if method.upper() == "POST":
+            return status_code == 429
+        return super().is_retry(method, status_code, has_retry_after)
+
+
+def _create_session() -> requests.Session:
+    """
+    Create a ``requests.Session`` configured with the TestRail retry
+    policy (3 retries, backoff factor 1, ``raise_on_status=False`` so
+    the final response always flows into ``_handle_response`` for
+    correct exception mapping).
+
+    Returns:
+        A configured ``requests.Session``.
+    """
+    session = requests.Session()
+    retry_strategy = _TestRailRetry(
+        total=3,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=None,
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry_strategy)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session
+
+
+def _serialize_param_value(value: Any) -> str:
+    """
+    Serialize a single query parameter value for the TestRail API.
+
+    Booleans become ``"1"``/``"0"`` (TestRail's PHP backend treats
+    ``"True"`` as 0, silently inverting filters) and lists/tuples
+    become comma-separated strings as required by multi-value filters.
+
+    Args:
+        value: The parameter value to serialize.
+
+    Returns:
+        The serialized string value.
+    """
+    if isinstance(value, bool):
+        return str(int(value))
+    if isinstance(value, list | tuple):
+        return ",".join(_serialize_param_value(item) for item in value)
+    return str(value)
+
+
 class BaseAPI:
     """
     Base class for all TestRail API modules.
@@ -65,28 +144,31 @@ class BaseAPI:
         """
         Initialize the base API class with a client instance.
 
+        If the client provides a ``requests.Session`` (as
+        ``TestRailAPI`` does), it is shared so that all submodules use
+        a single connection pool. Otherwise (standalone usage) a new
+        session with the TestRail retry policy is created.
+
         Args:
             client: The TestRailAPI client instance
         """
         self.client = client
         self.logger = logging.getLogger(__name__)
 
-        # Set up session with retry strategy
-        self.session = requests.Session()
-        retry_strategy = Retry(
-            total=3,
-            backoff_factor=1,
-            status_forcelist=[429, 500, 502, 503, 504],
-        )
-        adapter = HTTPAdapter(max_retries=retry_strategy)
-        self.session.mount("http://", adapter)
-        self.session.mount("https://", adapter)
+        client_session = getattr(client, "session", None)
+        if isinstance(client_session, requests.Session):
+            self.session = client_session
+        else:
+            self.session = _create_session()
 
     def _build_url(
         self, endpoint: str, params: dict[str, Any] | None = None
     ) -> str:
         """
         Build the complete URL for an API request.
+
+        Booleans are rendered as ``1``/``0`` and lists/tuples as
+        comma-separated values, as expected by the TestRail API.
 
         Args:
             endpoint: The API endpoint path
@@ -97,9 +179,11 @@ class BaseAPI:
         """
         url = f"{self.client.base_url}/index.php?/api/v2/{endpoint}"
         if params:
-            # Filter out None values and convert to strings
+            # Filter out None values and serialize the rest
             filtered_params = {
-                k: str(v) for k, v in params.items() if v is not None
+                k: _serialize_param_value(v)
+                for k, v in params.items()
+                if v is not None
             }
             if filtered_params:
                 url += f"&{urlencode(filtered_params)}"
@@ -124,21 +208,29 @@ class BaseAPI:
                 "No valid authentication method found. Please provide either an API key or password."
             )
 
-    def _handle_response(self, response: requests.Response) -> Any:
+    def _handle_response(
+        self, response: requests.Response, raw: bool = False
+    ) -> Any:
         """
         Handle API response and raise appropriate exceptions.
 
         Args:
             response: The HTTP response object
+            raw: If True, return the raw response body as bytes on
+                success instead of parsing it as JSON (for binary
+                endpoints such as ``get_attachment`` and ``get_bdd``).
 
         Returns:
-            Parsed JSON response data
+            Parsed JSON response data, or raw bytes when ``raw=True``
 
         Raises:
             TestRailRateLimitError: If rate limit is exceeded
             TestRailAPIException: For other API errors
         """
-        if response.status_code == 200:
+        if 200 <= response.status_code < 300:
+            if raw:
+                return response.content
+
             # Handle empty responses (common for delete operations)
             response_text = response.text.strip()
             if not response_text:
@@ -197,6 +289,8 @@ class BaseAPI:
         endpoint: str,
         data: dict[str, Any] | None = None,
         params: dict[str, Any] | None = None,
+        *,
+        raw: bool = False,
         **kwargs: Any,
     ) -> Any:
         """
@@ -207,10 +301,13 @@ class BaseAPI:
             endpoint: The API endpoint to send the request to.
             data: The data to send with the request, if any.
             params: Query parameters for the request.
+            raw: If True, return the raw response body as bytes
+                instead of parsing it as JSON.
             **kwargs: Additional arguments to pass to the request.
 
         Returns:
-            Parsed JSON response from the API.
+            Parsed JSON response from the API, or raw bytes when
+            ``raw=True``.
 
         Raises:
             TestRailAPIError: For various API-related errors
@@ -243,7 +340,7 @@ class BaseAPI:
                 **kwargs,
             )
 
-            return self._handle_response(response)
+            return self._handle_response(response, raw=raw)
 
         except requests.exceptions.RequestException as e:
             raise TestRailAPIException(f"Request failed: {e}") from e
@@ -257,10 +354,14 @@ class BaseAPI:
         self,
         endpoint: str,
         params: dict[str, Any] | None = None,
+        *,
+        raw: bool = False,
         **kwargs: Any,
     ) -> Any:
         """Make a GET request to the TestRail API."""
-        return self._api_request("GET", endpoint, params=params, **kwargs)
+        return self._api_request(
+            "GET", endpoint, params=params, raw=raw, **kwargs
+        )
 
     def _post(
         self,
@@ -270,3 +371,56 @@ class BaseAPI:
     ) -> Any:
         """Make a POST request to the TestRail API."""
         return self._api_request("POST", endpoint, data=data, **kwargs)
+
+    def _post_multipart(
+        self,
+        endpoint: str,
+        file_path: str,
+        **kwargs: Any,
+    ) -> Any:
+        """
+        Make a multipart/form-data POST request uploading a file.
+
+        TestRail's file-upload endpoints (``add_attachment_to_*`` and
+        ``add_bdd``) expect the file bytes in an ``attachment`` form
+        field. The JSON Content-Type header must not be set so that
+        requests can generate the multipart boundary header.
+
+        Args:
+            endpoint: The API endpoint to send the request to.
+            file_path: Path to the file to upload.
+            **kwargs: Additional arguments to pass to the request.
+
+        Returns:
+            Parsed JSON response from the API.
+
+        Raises:
+            FileNotFoundError: If ``file_path`` does not exist.
+            TestRailAPIError: For various API-related errors
+        """
+        url = self._build_url(endpoint)
+        auth = self._get_auth()
+        timeout = (
+            self.client.timeout if hasattr(self.client, "timeout") else 30
+        )
+
+        with open(file_path, "rb") as attachment:
+            try:
+                response = self.session.request(
+                    method="POST",
+                    url=url,
+                    auth=auth,
+                    files={"attachment": attachment},
+                    timeout=timeout,
+                    **kwargs,
+                )
+
+                return self._handle_response(response)
+
+            except requests.exceptions.RequestException as e:
+                raise TestRailAPIException(f"Request failed: {e}") from e
+            except TestRailAPIError:
+                # Re-raise our custom exceptions
+                raise
+            except Exception as e:
+                raise TestRailAPIException(f"Unexpected error: {e}") from e

--- a/src/testrail_api_module/base.pyi
+++ b/src/testrail_api_module/base.pyi
@@ -1,6 +1,8 @@
-from typing import Any
+import logging
+from typing import Any, Literal, overload
 
 import requests
+from urllib3.util.retry import Retry
 
 class TestRailAPIError(Exception):
     """Base exception class for TestRail API errors."""
@@ -14,14 +16,28 @@ class TestRailRateLimitError(TestRailAPIError):
 class TestRailAPIException(TestRailAPIError):
     """Raised for general API errors."""
 
-    status_code: Any
-    response_text: Any
+    status_code: int | None
+    response_text: str | None
     def __init__(
         self,
         message: str,
         status_code: int | None = None,
         response_text: str | None = None,
     ) -> None: ...
+
+class _TestRailRetry(Retry):
+    """Retry policy tailored to the TestRail API."""
+
+    def _is_method_retryable(self, method: str) -> bool: ...
+    def is_retry(
+        self, method: str, status_code: int, has_retry_after: bool = False
+    ) -> bool: ...
+
+def _create_session() -> requests.Session:
+    """Create a requests.Session with the TestRail retry policy."""
+
+def _serialize_param_value(value: Any) -> str:
+    """Serialize a single query parameter value for the TestRail API."""
 
 class BaseAPI:
     """
@@ -31,8 +47,8 @@ class BaseAPI:
     """
 
     client: Any
-    logger: Any
-    session: Any
+    logger: logging.Logger
+    session: requests.Session
     def __init__(self, client: Any) -> None:
         """
         Initialize the base API class with a client instance.
@@ -63,54 +79,59 @@ class BaseAPI:
         Raises:
             TestRailAuthenticationError: If no valid authentication is available
         """
+    @overload
     def _handle_response(
-        self, response: requests.Response
-    ) -> dict[str, Any] | list[dict[str, Any]]:
-        """
-        Handle API response and raise appropriate exceptions.
-
-        Args:
-            response: The HTTP response object
-
-        Returns:
-            Parsed JSON response data
-
-        Raises:
-            TestRailRateLimitError: If rate limit is exceeded
-            TestRailAPIException: For other API errors
-        """
+        self, response: requests.Response, raw: Literal[False] = False
+    ) -> dict[str, Any] | list[dict[str, Any]]: ...
+    @overload
+    def _handle_response(
+        self, response: requests.Response, raw: Literal[True]
+    ) -> bytes: ...
+    @overload
     def _api_request(
         self,
         method: str,
         endpoint: str,
         data: dict[str, Any] | None = None,
         params: dict[str, Any] | None = None,
+        *,
+        raw: Literal[False] = False,
         **kwargs: Any,
-    ) -> dict[str, Any] | list[dict[str, Any]]:
-        """
-        Make an API request to TestRail following official patterns.
-
-        Args:
-            method: The HTTP method to use for the request (e.g., 'GET', 'POST').
-            endpoint: The API endpoint to send the request to.
-            data: The data to send with the request, if any.
-            params: Query parameters for the request.
-            **kwargs: Additional arguments to pass to the request.
-
-        Returns:
-            Parsed JSON response from the API.
-
-        Raises:
-            TestRailAPIError: For various API-related errors
-        """
+    ) -> dict[str, Any] | list[dict[str, Any]]: ...
+    @overload
+    def _api_request(
+        self,
+        method: str,
+        endpoint: str,
+        data: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+        *,
+        raw: Literal[True],
+        **kwargs: Any,
+    ) -> bytes: ...
+    @overload
     def _get(
         self,
         endpoint: str,
         params: dict[str, Any] | None = None,
+        *,
+        raw: Literal[False] = False,
         **kwargs: Any,
-    ) -> dict[str, Any] | list[dict[str, Any]]:
-        """Make a GET request to the TestRail API."""
+    ) -> dict[str, Any] | list[dict[str, Any]]: ...
+    @overload
+    def _get(
+        self,
+        endpoint: str,
+        params: dict[str, Any] | None = None,
+        *,
+        raw: Literal[True],
+        **kwargs: Any,
+    ) -> bytes: ...
     def _post(
         self, endpoint: str, data: dict[str, Any] | None = None, **kwargs: Any
     ) -> dict[str, Any] | list[dict[str, Any]]:
         """Make a POST request to the TestRail API."""
+    def _post_multipart(
+        self, endpoint: str, file_path: str, **kwargs: Any
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        """Make a multipart/form-data POST request uploading a file."""

--- a/src/testrail_api_module/bdd.py
+++ b/src/testrail_api_module/bdd.py
@@ -19,7 +19,7 @@ class BDDAPI(BaseAPI):
     for test cases in TestRail.
     """
 
-    def get_bdd(self, case_id: int) -> dict[str, Any]:
+    def get_bdd(self, case_id: int) -> bytes:
         """
         Export a BDD scenario from a test case as a .feature file.
 
@@ -27,32 +27,29 @@ class BDDAPI(BaseAPI):
             case_id: The ID of the test case to export.
 
         Returns:
-            Dict containing the BDD scenario data in .feature
-            file format.
+            The raw .feature file content as bytes (Gherkin syntax).
 
         Raises:
             TestRailAPIError: If the API request fails.
         """
-        return self._api_request("GET", f"get_bdd/{case_id}")
+        return self._get(f"get_bdd/{case_id}", raw=True)
 
-    def add_bdd(
-        self,
-        section_id: int,
-        feature_file: str,
-        description: str | None = None,
-    ) -> dict[str, Any]:
+    def add_bdd(self, section_id: int, feature_file: str) -> dict[str, Any]:
         """
         Import/upload a BDD scenario from a .feature file into a
         section.
+
+        The file is uploaded as ``multipart/form-data`` with the file
+        bytes in an ``attachment`` form field, matching the official
+        TestRail API contract.
 
         Args:
             section_id: The ID of the section to import the BDD
                 scenario into.
             feature_file: The path to the .feature file to import.
-            description: Optional description for the BDD scenario.
 
         Returns:
-            Dict containing the created BDD scenario data.
+            Dict containing the created test case data.
 
         Raises:
             FileNotFoundError: If the specified feature file does
@@ -60,11 +57,7 @@ class BDDAPI(BaseAPI):
             TestRailAPIError: If the API request fails.
         """
         try:
-            with open(feature_file) as file:
-                data = {"file": file.read()}
-                if description:
-                    data["description"] = description
-                return self._api_request("POST", f"add_bdd/{section_id}", data)
+            return self._post_multipart(f"add_bdd/{section_id}", feature_file)
         except FileNotFoundError as e:
             raise FileNotFoundError(
                 f"Feature file not found: {feature_file}"

--- a/src/testrail_api_module/bdd.pyi
+++ b/src/testrail_api_module/bdd.pyi
@@ -4,7 +4,7 @@ from .base import BaseAPI as BaseAPI
 
 class BDDAPI(BaseAPI):
     """API for managing BDD scenarios in TestRail."""
-    def get_bdd(self, case_id: int) -> dict[str, Any]:
+    def get_bdd(self, case_id: int) -> bytes:
         """
         Export a BDD scenario from a test case as a .feature file.
 
@@ -12,24 +12,18 @@ class BDDAPI(BaseAPI):
             case_id: The ID of the test case to export.
 
         Returns:
-            Dict containing the BDD scenario data in .feature file format.
+            The raw .feature file content as bytes (Gherkin syntax).
         """
-    def add_bdd(
-        self,
-        section_id: int,
-        feature_file: str,
-        description: str | None = None,
-    ) -> dict[str, Any]:
+    def add_bdd(self, section_id: int, feature_file: str) -> dict[str, Any]:
         """
         Import/upload a BDD scenario from a .feature file into a section.
 
         Args:
             section_id: The ID of the section to import the BDD scenario into.
             feature_file: The path to the .feature file to import.
-            description: Optional description for the BDD scenario.
 
         Returns:
-            Dict containing the created BDD scenario data.
+            Dict containing the created test case data.
 
         Raises:
             FileNotFoundError: If the specified feature file does not exist.

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -38,129 +38,331 @@ class TestAttachmentsAPI:
         """Create an AttachmentsAPI instance with mocked client."""
         return AttachmentsAPI(mock_client)
 
+    @pytest.fixture
+    def sample_attachment_data(self) -> dict:
+        """Sample attachment data returned by upload endpoints."""
+        return {"attachment_id": 443}
+
     def test_init(self, mock_client: Mock) -> None:
         """Test AttachmentsAPI initialization."""
         api = AttachmentsAPI(mock_client)
         assert api.client == mock_client
         assert hasattr(api, "logger")
 
-    def test_get_attachment(self, attachments_api: AttachmentsAPI) -> None:
-        """Test get_attachment method."""
-        with patch.object(attachments_api, "_api_request") as mock_request:
-            mock_request.return_value = {"id": 1, "name": "file.txt"}
+    def test_add_attachment_to_case(
+        self,
+        attachments_api: AttachmentsAPI,
+        sample_attachment_data: dict,
+    ) -> None:
+        """Test add_attachment_to_case uploads via multipart."""
+        with patch.object(
+            attachments_api, "_post_multipart"
+        ) as mock_multipart:
+            mock_multipart.return_value = sample_attachment_data
+
+            result = attachments_api.add_attachment_to_case(
+                case_id=1, file_path="/path/to/file.png"
+            )
+
+            mock_multipart.assert_called_once_with(
+                "add_attachment_to_case/1", "/path/to/file.png"
+            )
+            assert result == {"attachment_id": 443}
+
+    def test_add_attachment_to_plan(
+        self,
+        attachments_api: AttachmentsAPI,
+        sample_attachment_data: dict,
+    ) -> None:
+        """Test add_attachment_to_plan uploads via multipart."""
+        with patch.object(
+            attachments_api, "_post_multipart"
+        ) as mock_multipart:
+            mock_multipart.return_value = sample_attachment_data
+
+            result = attachments_api.add_attachment_to_plan(
+                plan_id=2, file_path="/path/to/file.png"
+            )
+
+            mock_multipart.assert_called_once_with(
+                "add_attachment_to_plan/2", "/path/to/file.png"
+            )
+            assert result == {"attachment_id": 443}
+
+    def test_add_attachment_to_plan_entry(
+        self,
+        attachments_api: AttachmentsAPI,
+        sample_attachment_data: dict,
+    ) -> None:
+        """Test add_attachment_to_plan_entry uses both plan and entry IDs."""
+        with patch.object(
+            attachments_api, "_post_multipart"
+        ) as mock_multipart:
+            mock_multipart.return_value = sample_attachment_data
+
+            result = attachments_api.add_attachment_to_plan_entry(
+                plan_id=2, entry_id=7, file_path="/path/to/file.png"
+            )
+
+            mock_multipart.assert_called_once_with(
+                "add_attachment_to_plan_entry/2/7", "/path/to/file.png"
+            )
+            assert result == {"attachment_id": 443}
+
+    def test_add_attachment_to_result(
+        self,
+        attachments_api: AttachmentsAPI,
+        sample_attachment_data: dict,
+    ) -> None:
+        """Test add_attachment_to_result uploads via multipart."""
+        with patch.object(
+            attachments_api, "_post_multipart"
+        ) as mock_multipart:
+            mock_multipart.return_value = sample_attachment_data
+
+            result = attachments_api.add_attachment_to_result(
+                result_id=3, file_path="/path/to/file.png"
+            )
+
+            mock_multipart.assert_called_once_with(
+                "add_attachment_to_result/3", "/path/to/file.png"
+            )
+            assert result == {"attachment_id": 443}
+
+    def test_add_attachment_to_run(
+        self,
+        attachments_api: AttachmentsAPI,
+        sample_attachment_data: dict,
+    ) -> None:
+        """Test add_attachment_to_run uploads via multipart."""
+        with patch.object(
+            attachments_api, "_post_multipart"
+        ) as mock_multipart:
+            mock_multipart.return_value = sample_attachment_data
+
+            result = attachments_api.add_attachment_to_run(
+                run_id=4, file_path="/path/to/file.png"
+            )
+
+            mock_multipart.assert_called_once_with(
+                "add_attachment_to_run/4", "/path/to/file.png"
+            )
+            assert result == {"attachment_id": 443}
+
+    def test_add_attachment_file_not_found(
+        self, attachments_api: AttachmentsAPI
+    ) -> None:
+        """Test upload methods propagate FileNotFoundError."""
+        with patch.object(
+            attachments_api, "_post_multipart"
+        ) as mock_multipart:
+            mock_multipart.side_effect = FileNotFoundError("missing")
+
+            with pytest.raises(FileNotFoundError):
+                attachments_api.add_attachment_to_case(
+                    case_id=1, file_path="/nonexistent/file.png"
+                )
+
+    def test_get_attachments_for_case_minimal(
+        self, attachments_api: AttachmentsAPI
+    ) -> None:
+        """Test get_attachments_for_case with minimal parameters."""
+        with patch.object(attachments_api, "_get") as mock_get:
+            mock_get.return_value = [{"id": 1, "name": "file.png"}]
+
+            result = attachments_api.get_attachments_for_case(case_id=1)
+
+            mock_get.assert_called_once_with(
+                "get_attachments_for_case/1", params={}
+            )
+            assert result == [{"id": 1, "name": "file.png"}]
+
+    def test_get_attachments_for_case_all_params(
+        self, attachments_api: AttachmentsAPI
+    ) -> None:
+        """Test get_attachments_for_case with limit and offset."""
+        with patch.object(attachments_api, "_get") as mock_get:
+            mock_get.return_value = {
+                "offset": 50,
+                "limit": 25,
+                "size": 25,
+                "attachments": [{"id": 1}],
+            }
+
+            result = attachments_api.get_attachments_for_case(
+                case_id=1, limit=25, offset=50
+            )
+
+            mock_get.assert_called_once_with(
+                "get_attachments_for_case/1",
+                params={"limit": 25, "offset": 50},
+            )
+            assert result["attachments"] == [{"id": 1}]
+
+    def test_get_attachments_for_case_none_params(
+        self, attachments_api: AttachmentsAPI
+    ) -> None:
+        """Test get_attachments_for_case excludes None parameters."""
+        with patch.object(attachments_api, "_get") as mock_get:
+            mock_get.return_value = []
+
+            result = attachments_api.get_attachments_for_case(
+                case_id=1, limit=None, offset=None
+            )
+
+            mock_get.assert_called_once_with(
+                "get_attachments_for_case/1", params={}
+            )
+            assert result == []
+
+    def test_get_attachments_for_plan_minimal(
+        self, attachments_api: AttachmentsAPI
+    ) -> None:
+        """Test get_attachments_for_plan with minimal parameters."""
+        with patch.object(attachments_api, "_get") as mock_get:
+            mock_get.return_value = [{"id": 2}]
+
+            result = attachments_api.get_attachments_for_plan(plan_id=2)
+
+            mock_get.assert_called_once_with(
+                "get_attachments_for_plan/2", params={}
+            )
+            assert result == [{"id": 2}]
+
+    def test_get_attachments_for_plan_all_params(
+        self, attachments_api: AttachmentsAPI
+    ) -> None:
+        """Test get_attachments_for_plan with limit and offset."""
+        with patch.object(attachments_api, "_get") as mock_get:
+            mock_get.return_value = [{"id": 2}]
+
+            result = attachments_api.get_attachments_for_plan(
+                plan_id=2, limit=10, offset=20
+            )
+
+            mock_get.assert_called_once_with(
+                "get_attachments_for_plan/2",
+                params={"limit": 10, "offset": 20},
+            )
+            assert result == [{"id": 2}]
+
+    def test_get_attachments_for_plan_entry(
+        self, attachments_api: AttachmentsAPI
+    ) -> None:
+        """Test get_attachments_for_plan_entry uses both IDs."""
+        with patch.object(attachments_api, "_get") as mock_get:
+            mock_get.return_value = [{"id": 3}]
+
+            result = attachments_api.get_attachments_for_plan_entry(
+                plan_id=2, entry_id=7
+            )
+
+            mock_get.assert_called_once_with(
+                "get_attachments_for_plan_entry/2/7"
+            )
+            assert result == [{"id": 3}]
+
+    def test_get_attachments_for_run_minimal(
+        self, attachments_api: AttachmentsAPI
+    ) -> None:
+        """Test get_attachments_for_run with minimal parameters."""
+        with patch.object(attachments_api, "_get") as mock_get:
+            mock_get.return_value = [{"id": 4}]
+
+            result = attachments_api.get_attachments_for_run(run_id=4)
+
+            mock_get.assert_called_once_with(
+                "get_attachments_for_run/4", params={}
+            )
+            assert result == [{"id": 4}]
+
+    def test_get_attachments_for_run_all_params(
+        self, attachments_api: AttachmentsAPI
+    ) -> None:
+        """Test get_attachments_for_run with limit and offset."""
+        with patch.object(attachments_api, "_get") as mock_get:
+            mock_get.return_value = [{"id": 4}]
+
+            result = attachments_api.get_attachments_for_run(
+                run_id=4, limit=5, offset=0
+            )
+
+            mock_get.assert_called_once_with(
+                "get_attachments_for_run/4",
+                params={"limit": 5, "offset": 0},
+            )
+            assert result == [{"id": 4}]
+
+    def test_get_attachments_for_test(
+        self, attachments_api: AttachmentsAPI
+    ) -> None:
+        """Test get_attachments_for_test method."""
+        with patch.object(attachments_api, "_get") as mock_get:
+            mock_get.return_value = [{"id": 5}]
+
+            result = attachments_api.get_attachments_for_test(test_id=5)
+
+            mock_get.assert_called_once_with("get_attachments_for_test/5")
+            assert result == [{"id": 5}]
+
+    def test_get_attachment_int_id(
+        self, attachments_api: AttachmentsAPI
+    ) -> None:
+        """Test get_attachment downloads raw bytes with an integer ID."""
+        with patch.object(attachments_api, "_get") as mock_get:
+            mock_get.return_value = b"\x89PNG binary data"
 
             result = attachments_api.get_attachment(attachment_id=1)
 
-            mock_request.assert_called_once_with("GET", "get_attachment/1")
-            assert result == {"id": 1, "name": "file.txt"}
+            mock_get.assert_called_once_with("get_attachment/1", raw=True)
+            assert result == b"\x89PNG binary data"
 
-    def test_get_attachments(self, attachments_api: AttachmentsAPI) -> None:
-        """Test get_attachments method."""
-        with patch.object(attachments_api, "_api_request") as mock_request:
-            mock_request.return_value = [
-                {"id": 1, "name": "file1.txt"},
-                {"id": 2, "name": "file2.txt"},
-            ]
-
-            result = attachments_api.get_attachments(
-                entity_type="case", entity_id=1
-            )
-
-            mock_request.assert_called_once_with(
-                "GET", "get_attachments/case/1"
-            )
-            assert len(result) == 2
-
-    @pytest.mark.parametrize("entity_type", ["case", "run", "plan", "project"])
-    def test_get_attachments_different_entity_types(
-        self, attachments_api: AttachmentsAPI, entity_type: str
-    ) -> None:
-        """Test get_attachments with different entity types."""
-        with patch.object(attachments_api, "_api_request") as mock_request:
-            mock_request.return_value = [{"id": 1}]
-
-            attachments_api.get_attachments(
-                entity_type=entity_type, entity_id=1
-            )
-
-            mock_request.assert_called_once_with(
-                "GET", f"get_attachments/{entity_type}/1"
-            )
-
-    def test_add_attachment_minimal(
+    def test_get_attachment_uuid_id(
         self, attachments_api: AttachmentsAPI
     ) -> None:
-        """Test add_attachment with minimal required parameters."""
-        with patch.object(attachments_api, "_api_request") as mock_request:
-            mock_request.return_value = {"id": 1, "name": "file.txt"}
+        """Test get_attachment with a UUID string ID (newer TestRail)."""
+        uuid = "5c5e8b3a-21c7-4f73-a0ef-d09e9f1b8c19"
+        with patch.object(attachments_api, "_get") as mock_get:
+            mock_get.return_value = b"binary"
 
-            result = attachments_api.add_attachment(
-                entity_type="case", entity_id=1, file_path="/path/to/file.txt"
+            result = attachments_api.get_attachment(attachment_id=uuid)
+
+            mock_get.assert_called_once_with(
+                f"get_attachment/{uuid}", raw=True
             )
+            assert result == b"binary"
 
-            expected_data = {"file": "/path/to/file.txt"}
-            mock_request.assert_called_once_with(
-                "POST", "add_attachment/case/1", data=expected_data
-            )
-            assert result == {"id": 1, "name": "file.txt"}
-
-    def test_add_attachment_with_description(
+    def test_delete_attachment_int_id(
         self, attachments_api: AttachmentsAPI
     ) -> None:
-        """Test add_attachment with description."""
-        with patch.object(attachments_api, "_api_request") as mock_request:
-            mock_request.return_value = {"id": 1, "name": "file.txt"}
-
-            attachments_api.add_attachment(
-                entity_type="case",
-                entity_id=1,
-                file_path="/path/to/file.txt",
-                description="Test file",
-            )
-
-            expected_data = {
-                "file": "/path/to/file.txt",
-                "description": "Test file",
-            }
-            mock_request.assert_called_once_with(
-                "POST", "add_attachment/case/1", data=expected_data
-            )
-
-    def test_add_attachment_without_description(
-        self, attachments_api: AttachmentsAPI
-    ) -> None:
-        """Test add_attachment without description."""
-        with patch.object(attachments_api, "_api_request") as mock_request:
-            mock_request.return_value = {"id": 1}
-
-            attachments_api.add_attachment(
-                entity_type="run",
-                entity_id=1,
-                file_path="/path/to/file.txt",
-                description=None,
-            )
-
-            expected_data = {"file": "/path/to/file.txt"}
-            mock_request.assert_called_once_with(
-                "POST", "add_attachment/run/1", data=expected_data
-            )
-
-    def test_delete_attachment(self, attachments_api: AttachmentsAPI) -> None:
-        """Test delete_attachment method."""
-        with patch.object(attachments_api, "_api_request") as mock_request:
-            mock_request.return_value = {}
+        """Test delete_attachment with an integer ID."""
+        with patch.object(attachments_api, "_post") as mock_post:
+            mock_post.return_value = {}
 
             result = attachments_api.delete_attachment(attachment_id=1)
 
-            mock_request.assert_called_once_with("POST", "delete_attachment/1")
+            mock_post.assert_called_once_with("delete_attachment/1")
+            assert result == {}
+
+    def test_delete_attachment_uuid_id(
+        self, attachments_api: AttachmentsAPI
+    ) -> None:
+        """Test delete_attachment with a UUID string ID (newer TestRail)."""
+        uuid = "5c5e8b3a-21c7-4f73-a0ef-d09e9f1b8c19"
+        with patch.object(attachments_api, "_post") as mock_post:
+            mock_post.return_value = {}
+
+            result = attachments_api.delete_attachment(attachment_id=uuid)
+
+            mock_post.assert_called_once_with(f"delete_attachment/{uuid}")
             assert result == {}
 
     def test_api_request_failure(
         self, attachments_api: AttachmentsAPI
     ) -> None:
         """Test behavior when API request fails."""
-        with patch.object(attachments_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAPIError("API request failed")
+        with patch.object(attachments_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAPIError("API request failed")
 
             with pytest.raises(TestRailAPIError, match="API request failed"):
                 attachments_api.get_attachment(attachment_id=1)
@@ -169,8 +371,8 @@ class TestAttachmentsAPI:
         self, attachments_api: AttachmentsAPI
     ) -> None:
         """Test behavior when authentication fails."""
-        with patch.object(attachments_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAuthenticationError(
+        with patch.object(attachments_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAuthenticationError(
                 "Authentication failed"
             )
 
@@ -181,8 +383,8 @@ class TestAttachmentsAPI:
 
     def test_rate_limit_error(self, attachments_api: AttachmentsAPI) -> None:
         """Test behavior when rate limit is exceeded."""
-        with patch.object(attachments_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailRateLimitError(
+        with patch.object(attachments_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailRateLimitError(
                 "Rate limit exceeded"
             )
 
@@ -190,3 +392,47 @@ class TestAttachmentsAPI:
                 TestRailRateLimitError, match="Rate limit exceeded"
             ):
                 attachments_api.get_attachment(attachment_id=1)
+
+    def test_upload_authentication_error(
+        self, attachments_api: AttachmentsAPI
+    ) -> None:
+        """Test upload methods propagate authentication errors."""
+        with patch.object(
+            attachments_api, "_post_multipart"
+        ) as mock_multipart:
+            mock_multipart.side_effect = TestRailAuthenticationError(
+                "Authentication failed"
+            )
+
+            with pytest.raises(
+                TestRailAuthenticationError, match="Authentication failed"
+            ):
+                attachments_api.add_attachment_to_case(
+                    case_id=1, file_path="/path/to/file.png"
+                )
+
+    def test_upload_rate_limit_error(
+        self, attachments_api: AttachmentsAPI
+    ) -> None:
+        """Test upload methods propagate rate limit errors."""
+        with patch.object(
+            attachments_api, "_post_multipart"
+        ) as mock_multipart:
+            mock_multipart.side_effect = TestRailRateLimitError(
+                "Rate limit exceeded"
+            )
+
+            with pytest.raises(
+                TestRailRateLimitError, match="Rate limit exceeded"
+            ):
+                attachments_api.add_attachment_to_run(
+                    run_id=1, file_path="/path/to/file.png"
+                )
+
+    def test_removed_generic_methods_are_gone(
+        self, attachments_api: AttachmentsAPI
+    ) -> None:
+        """Test the fabricated generic methods were removed (they called
+        endpoints that do not exist in any TestRail version)."""
+        assert not hasattr(attachments_api, "get_attachments")
+        assert not hasattr(attachments_api, "add_attachment")

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -18,6 +18,7 @@ from testrail_api_module.base import (
     TestRailAPIException,
     TestRailAuthenticationError,
     TestRailRateLimitError,
+    _TestRailRetry,
 )
 
 if TYPE_CHECKING:
@@ -103,6 +104,90 @@ class TestBaseAPI:
         assert "http://" in api.session.adapters
         assert "https://" in api.session.adapters
 
+    def test_init_shares_client_session(self) -> None:
+        """Test BaseAPI reuses the client's requests.Session when provided."""
+        shared_session = requests.Session()
+        client = Mock()
+        client.session = shared_session
+        api = BaseAPI(client)
+        assert api.session is shared_session
+        shared_session.close()
+
+    def test_init_creates_own_session_without_client_session(
+        self, mock_client: Mock
+    ) -> None:
+        """Test BaseAPI creates its own session when the client has none.
+
+        A Mock attribute is not a real requests.Session, so standalone
+        usage falls back to creating a configured session.
+        """
+        api = BaseAPI(mock_client)
+        assert isinstance(api.session, requests.Session)
+        assert api.session is not mock_client.session
+
+    def test_session_retry_configuration(self, base_api: BaseAPI) -> None:
+        """Test the mounted adapter uses the TestRail retry policy."""
+        adapter = base_api.session.get_adapter("https://testrail.example.com")
+        retry = adapter.max_retries
+        assert isinstance(retry, _TestRailRetry)
+        assert retry.total == 3
+        assert retry.backoff_factor == 1
+        assert retry.raise_on_status is False
+        assert retry.allowed_methods is None
+        assert set(retry.status_forcelist) == {429, 500, 502, 503, 504}
+
+    def test_retry_policy_get_retries_on_429_and_5xx(self) -> None:
+        """Test the retry policy retries GETs on 429 and 5xx statuses."""
+        retry = _TestRailRetry(
+            total=3,
+            backoff_factor=1,
+            status_forcelist=[429, 500, 502, 503, 504],
+            allowed_methods=None,
+            raise_on_status=False,
+        )
+        assert retry.is_retry("GET", 429) is True
+        assert retry.is_retry("GET", 500) is True
+        assert retry.is_retry("GET", 503) is True
+        assert retry.is_retry("GET", 200) is False
+        assert retry._is_method_retryable("GET") is True
+
+    def test_retry_policy_post_retries_only_on_429(self) -> None:
+        """Test the retry policy retries POSTs on 429 only (writes are
+        not idempotent in TestRail, so 5xx must not be replayed)."""
+        retry = _TestRailRetry(
+            total=3,
+            backoff_factor=1,
+            status_forcelist=[429, 500, 502, 503, 504],
+            allowed_methods=None,
+            raise_on_status=False,
+        )
+        assert retry.is_retry("POST", 429) is True
+        assert retry.is_retry("POST", 500) is False
+        assert retry.is_retry("POST", 502) is False
+        assert retry.is_retry("POST", 503) is False
+        assert retry.is_retry("POST", 503, has_retry_after=True) is False
+        assert retry.is_retry("post", 500) is False
+        # Read errors (request may have reached the server) must not
+        # be retried for POSTs either.
+        assert retry._is_method_retryable("POST") is False
+
+    def test_retry_policy_survives_increment(self) -> None:
+        """Test the retry policy class is preserved across increment()
+        (urllib3 creates a new Retry instance per attempt)."""
+        retry = _TestRailRetry(
+            total=3,
+            backoff_factor=1,
+            status_forcelist=[429, 500, 502, 503, 504],
+            allowed_methods=None,
+            raise_on_status=False,
+        )
+        bumped = retry.increment(
+            method="GET", url="/", response=None, error=None
+        )
+        assert isinstance(bumped, _TestRailRetry)
+        assert bumped.total == 2
+        assert bumped.is_retry("POST", 500) is False
+
     def test_build_url_without_params(self, base_api: BaseAPI) -> None:
         """Test _build_url without parameters."""
         url = base_api._build_url("get_case/1")
@@ -135,9 +220,58 @@ class TestBaseAPI:
         """Test _build_url with complex parameter values."""
         params = {"ids": [1, 2, 3], "name": "test case"}
         url = base_api._build_url("get_cases/1", params=params)
-        # All values should be converted to strings
-        assert "ids" in url
-        assert "name" in url
+        # Lists are comma-joined ("," url-encodes to %2C)
+        assert "ids=1%2C2%2C3" in url
+        assert "name=test+case" in url
+
+    def test_build_url_serializes_true_as_1(self, base_api: BaseAPI) -> None:
+        """Test _build_url serializes True as 1 (TestRail's PHP backend
+        treats "True" as 0, silently inverting filters)."""
+        url = base_api._build_url("get_runs/1", params={"is_completed": True})
+        assert "is_completed=1" in url
+        assert "True" not in url
+
+    def test_build_url_serializes_false_as_0(self, base_api: BaseAPI) -> None:
+        """Test _build_url serializes False as 0."""
+        url = base_api._build_url("get_runs/1", params={"is_completed": False})
+        assert "is_completed=0" in url
+        assert "False" not in url
+
+    def test_build_url_serializes_list_as_comma_joined(
+        self, base_api: BaseAPI
+    ) -> None:
+        """Test _build_url comma-joins list filter values."""
+        url = base_api._build_url("get_cases/1", params={"created_by": [1, 2]})
+        assert "created_by=1%2C2" in url
+        assert "%5B" not in url  # no "[" from a Python repr
+
+    def test_build_url_serializes_tuple_as_comma_joined(
+        self, base_api: BaseAPI
+    ) -> None:
+        """Test _build_url comma-joins tuple filter values."""
+        url = base_api._build_url(
+            "get_cases/1", params={"priority_id": (4, 5)}
+        )
+        assert "priority_id=4%2C5" in url
+
+    def test_build_url_preserves_prejoined_string(
+        self, base_api: BaseAPI
+    ) -> None:
+        """Test _build_url leaves pre-joined string filters intact
+        (results.py/tests.py already comma-join their list params)."""
+        url = base_api._build_url(
+            "get_results/1", params={"status_id": "1,2,3"}
+        )
+        assert "status_id=1%2C2%2C3" in url
+
+    def test_build_url_serializes_bools_inside_lists(
+        self, base_api: BaseAPI
+    ) -> None:
+        """Test _build_url serializes booleans inside list values."""
+        url = base_api._build_url(
+            "get_cases/1", params={"flags": [True, False]}
+        )
+        assert "flags=1%2C0" in url
 
     def test_build_url_with_all_none_params(self, base_api: BaseAPI) -> None:
         """Test _build_url when all params are None (edge case)."""
@@ -270,6 +404,62 @@ class TestBaseAPI:
         result = base_api._handle_response(response)
         # Whitespace-only responses should be treated as empty
         assert result == {}
+
+    def test_handle_response_201_created(self, base_api: BaseAPI) -> None:
+        """Test _handle_response accepts 201 as success."""
+        response = Mock(spec=requests.Response)
+        response.status_code = 201
+        response.text = '{"id": 1}'
+        response.json.return_value = {"id": 1}
+
+        result = base_api._handle_response(response)
+        assert result == {"id": 1}
+
+    def test_handle_response_204_no_content(self, base_api: BaseAPI) -> None:
+        """Test _handle_response accepts 204 with empty body as success."""
+        response = Mock(spec=requests.Response)
+        response.status_code = 204
+        response.text = ""
+
+        result = base_api._handle_response(response)
+        assert result == {}
+
+    def test_handle_response_raw_returns_bytes(
+        self, base_api: BaseAPI
+    ) -> None:
+        """Test _handle_response with raw=True returns response.content."""
+        response = Mock(spec=requests.Response)
+        response.status_code = 200
+        response.content = b"\x89PNG binary data"
+
+        result = base_api._handle_response(response, raw=True)
+        assert result == b"\x89PNG binary data"
+
+    def test_handle_response_raw_skips_json_parsing(
+        self, base_api: BaseAPI
+    ) -> None:
+        """Test _handle_response with raw=True never parses JSON, so
+        non-JSON bodies (e.g. .feature files) succeed."""
+        response = Mock(spec=requests.Response)
+        response.status_code = 200
+        response.content = b"Feature: Login"
+        response.json.side_effect = json.JSONDecodeError(
+            "Invalid JSON", "Feature: Login", 0
+        )
+
+        result = base_api._handle_response(response, raw=True)
+        assert result == b"Feature: Login"
+        response.json.assert_not_called()
+
+    def test_handle_response_raw_error_still_raises(
+        self, base_api: BaseAPI
+    ) -> None:
+        """Test _handle_response with raw=True still maps error codes."""
+        response = Mock(spec=requests.Response)
+        response.status_code = 401
+
+        with pytest.raises(TestRailAuthenticationError):
+            base_api._handle_response(response, raw=True)
 
     def test_handle_response_invalid_json(self, base_api: BaseAPI) -> None:
         """Test _handle_response with invalid JSON (non-empty but malformed)."""
@@ -607,9 +797,21 @@ class TestBaseAPI:
         result = base_api._get("get_case/1", params={"limit": 10})
 
         mock_api_request.assert_called_once_with(
-            "GET", "get_case/1", params={"limit": 10}
+            "GET", "get_case/1", params={"limit": 10}, raw=False
         )
         assert result == {"id": 1}
+
+    @patch.object(BaseAPI, "_api_request")
+    def test_get_method_raw(self, mock_api_request, base_api: BaseAPI) -> None:
+        """Test _get method passes raw=True through to _api_request."""
+        mock_api_request.return_value = b"Feature: Login"
+
+        result = base_api._get("get_bdd/1", raw=True)
+
+        mock_api_request.assert_called_once_with(
+            "GET", "get_bdd/1", params=None, raw=True
+        )
+        assert result == b"Feature: Login"
 
     @patch.object(BaseAPI, "_api_request")
     def test_post_method(self, mock_api_request, base_api: BaseAPI) -> None:
@@ -634,7 +836,7 @@ class TestBaseAPI:
         result = base_api._get("get_case/1", params={"limit": 10}, timeout=60)
 
         mock_api_request.assert_called_once_with(
-            "GET", "get_case/1", params={"limit": 10}, timeout=60
+            "GET", "get_case/1", params={"limit": 10}, raw=False, timeout=60
         )
         assert result == {"id": 1}
 
@@ -652,3 +854,116 @@ class TestBaseAPI:
             "POST", "add_case/1", data=data, timeout=60
         )
         assert result == {"id": 1}
+
+    def test_api_request_raw_returns_bytes(self, base_api: BaseAPI) -> None:
+        """Test _api_request with raw=True returns raw bytes and does
+        not forward 'raw' to the session request."""
+        mock_response = Mock(spec=requests.Response)
+        mock_response.status_code = 200
+        mock_response.content = b"binary content"
+        base_api.session.request = Mock(return_value=mock_response)
+
+        result = base_api._api_request("GET", "get_attachment/1", raw=True)
+
+        assert result == b"binary content"
+        call_kwargs = base_api.session.request.call_args[1]
+        assert "raw" not in call_kwargs
+        assert call_kwargs["method"] == "GET"
+
+    def test_post_multipart_success(self, base_api: BaseAPI, tmp_path) -> None:
+        """Test _post_multipart uploads the opened file in an
+        'attachment' form field without the JSON Content-Type header."""
+        file_path = tmp_path / "evidence.png"
+        file_path.write_bytes(b"\x89PNG fake image bytes")
+
+        mock_response = Mock(spec=requests.Response)
+        mock_response.status_code = 200
+        mock_response.text = '{"attachment_id": 443}'
+        mock_response.json.return_value = {"attachment_id": 443}
+        base_api.session.request = Mock(return_value=mock_response)
+
+        result = base_api._post_multipart(
+            "add_attachment_to_case/1", str(file_path)
+        )
+
+        assert result == {"attachment_id": 443}
+        call_kwargs = base_api.session.request.call_args[1]
+        assert call_kwargs["method"] == "POST"
+        assert "add_attachment_to_case/1" in call_kwargs["url"]
+        assert call_kwargs["auth"] == ("testuser", "test_api_key")
+        assert call_kwargs["timeout"] == 30
+        # The file handle must be sent as the 'attachment' form field
+        assert "attachment" in call_kwargs["files"]
+        assert call_kwargs["files"]["attachment"].name == str(file_path)
+        # No JSON Content-Type header: requests must generate the
+        # multipart boundary header itself
+        assert "headers" not in call_kwargs
+        assert "json" not in call_kwargs
+
+    def test_post_multipart_missing_file(self, base_api: BaseAPI) -> None:
+        """Test _post_multipart raises FileNotFoundError for a missing
+        file (not a wrapped TestRailAPIException)."""
+        base_api.session.request = Mock()
+
+        with pytest.raises(FileNotFoundError):
+            base_api._post_multipart(
+                "add_attachment_to_case/1", "/nonexistent/file.png"
+            )
+        base_api.session.request.assert_not_called()
+
+    def test_post_multipart_authentication_error(
+        self, base_api: BaseAPI, tmp_path
+    ) -> None:
+        """Test _post_multipart maps 401 to TestRailAuthenticationError."""
+        file_path = tmp_path / "evidence.png"
+        file_path.write_bytes(b"data")
+
+        mock_response = Mock(spec=requests.Response)
+        mock_response.status_code = 401
+        base_api.session.request = Mock(return_value=mock_response)
+
+        with pytest.raises(
+            TestRailAuthenticationError, match="Authentication failed"
+        ):
+            base_api._post_multipart(
+                "add_attachment_to_case/1", str(file_path)
+            )
+
+    def test_post_multipart_rate_limit_error(
+        self, base_api: BaseAPI, tmp_path
+    ) -> None:
+        """Test _post_multipart maps 429 to TestRailRateLimitError."""
+        file_path = tmp_path / "evidence.png"
+        file_path.write_bytes(b"data")
+
+        mock_response = Mock(spec=requests.Response)
+        mock_response.status_code = 429
+        mock_response.headers = {}
+        base_api.session.request = Mock(return_value=mock_response)
+
+        with pytest.raises(
+            TestRailRateLimitError, match="Rate limit exceeded"
+        ):
+            base_api._post_multipart(
+                "add_attachment_to_case/1", str(file_path)
+            )
+
+    def test_post_multipart_request_exception(
+        self, base_api: BaseAPI, tmp_path
+    ) -> None:
+        """Test _post_multipart wraps RequestException."""
+        file_path = tmp_path / "evidence.png"
+        file_path.write_bytes(b"data")
+
+        base_api.session.request = Mock(
+            side_effect=requests.exceptions.RequestException(
+                "Connection error"
+            )
+        )
+
+        with pytest.raises(
+            TestRailAPIException, match="Request failed: Connection error"
+        ):
+            base_api._post_multipart(
+                "add_attachment_to_case/1", str(file_path)
+            )

--- a/tests/test_bdd.py
+++ b/tests/test_bdd.py
@@ -6,7 +6,7 @@ including edge cases, error handling, and proper API request formatting.
 """
 
 from typing import TYPE_CHECKING
-from unittest.mock import Mock, mock_open, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -38,6 +38,15 @@ class TestBDDAPI:
         """Create a BDDAPI instance with mocked client."""
         return BDDAPI(mock_client)
 
+    @pytest.fixture
+    def sample_case_data(self) -> dict:
+        """Sample test case data returned by add_bdd."""
+        return {
+            "id": 2136,
+            "title": "Users cannot login with invalid credentials",
+            "section_id": 188,
+        }
+
     def test_init(self, mock_client: Mock) -> None:
         """Test BDDAPI initialization."""
         api = BDDAPI(mock_client)
@@ -45,65 +54,34 @@ class TestBDDAPI:
         assert hasattr(api, "logger")
 
     def test_get_bdd(self, bdd_api: BDDAPI) -> None:
-        """Test get_bdd method."""
-        with patch.object(bdd_api, "_api_request") as mock_request:
-            mock_request.return_value = {
-                "feature": "Feature: Test Feature",
-                "scenarios": [],
-            }
+        """Test get_bdd downloads the raw .feature file content."""
+        with patch.object(bdd_api, "_get") as mock_get:
+            mock_get.return_value = b"Feature: Test Feature"
 
             result = bdd_api.get_bdd(case_id=1)
 
-            mock_request.assert_called_once_with("GET", "get_bdd/1")
-            assert "feature" in result
+            mock_get.assert_called_once_with("get_bdd/1", raw=True)
+            assert result == b"Feature: Test Feature"
 
-    def test_add_bdd_minimal(self, bdd_api: BDDAPI) -> None:
-        """Test add_bdd with minimal required parameters."""
-        with (
-            patch.object(bdd_api, "_api_request") as mock_request,
-            patch(
-                "builtins.open", mock_open(read_data="Feature: Test Feature")
-            ),
-        ):
-            mock_request.return_value = {"id": 1, "feature": "Test Feature"}
+    def test_add_bdd(self, bdd_api: BDDAPI, sample_case_data: dict) -> None:
+        """Test add_bdd uploads the .feature file via multipart."""
+        with patch.object(bdd_api, "_post_multipart") as mock_multipart:
+            mock_multipart.return_value = sample_case_data
 
             result = bdd_api.add_bdd(
-                section_id=1, feature_file="/path/to/feature.feature"
+                section_id=188, feature_file="/path/to/feature.feature"
             )
 
-            expected_data = {"file": "Feature: Test Feature"}
-            mock_request.assert_called_once_with(
-                "POST", "add_bdd/1", expected_data
+            mock_multipart.assert_called_once_with(
+                "add_bdd/188", "/path/to/feature.feature"
             )
-            assert result == {"id": 1, "feature": "Test Feature"}
-
-    def test_add_bdd_with_description(self, bdd_api: BDDAPI) -> None:
-        """Test add_bdd with description."""
-        with (
-            patch.object(bdd_api, "_api_request") as mock_request,
-            patch(
-                "builtins.open", mock_open(read_data="Feature: Test Feature")
-            ),
-        ):
-            mock_request.return_value = {"id": 1}
-
-            bdd_api.add_bdd(
-                section_id=1,
-                feature_file="/path/to/feature.feature",
-                description="Feature description",
-            )
-
-            expected_data = {
-                "file": "Feature: Test Feature",
-                "description": "Feature description",
-            }
-            mock_request.assert_called_once_with(
-                "POST", "add_bdd/1", expected_data
-            )
+            assert result == sample_case_data
 
     def test_add_bdd_file_not_found(self, bdd_api: BDDAPI) -> None:
         """Test add_bdd when file is not found."""
-        with patch("builtins.open", side_effect=FileNotFoundError):
+        with patch.object(bdd_api, "_post_multipart") as mock_multipart:
+            mock_multipart.side_effect = FileNotFoundError("missing")
+
             with pytest.raises(
                 FileNotFoundError, match="Feature file not found"
             ):
@@ -113,16 +91,16 @@ class TestBDDAPI:
 
     def test_api_request_failure(self, bdd_api: BDDAPI) -> None:
         """Test behavior when API request fails."""
-        with patch.object(bdd_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAPIError("API request failed")
+        with patch.object(bdd_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAPIError("API request failed")
 
             with pytest.raises(TestRailAPIError, match="API request failed"):
                 bdd_api.get_bdd(case_id=1)
 
     def test_authentication_error(self, bdd_api: BDDAPI) -> None:
         """Test behavior when authentication fails."""
-        with patch.object(bdd_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAuthenticationError(
+        with patch.object(bdd_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAuthenticationError(
                 "Authentication failed"
             )
 
@@ -133,8 +111,8 @@ class TestBDDAPI:
 
     def test_rate_limit_error(self, bdd_api: BDDAPI) -> None:
         """Test behavior when rate limit is exceeded."""
-        with patch.object(bdd_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailRateLimitError(
+        with patch.object(bdd_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailRateLimitError(
                 "Rate limit exceeded"
             )
 
@@ -142,3 +120,31 @@ class TestBDDAPI:
                 TestRailRateLimitError, match="Rate limit exceeded"
             ):
                 bdd_api.get_bdd(case_id=1)
+
+    def test_add_bdd_authentication_error(self, bdd_api: BDDAPI) -> None:
+        """Test add_bdd propagates authentication errors."""
+        with patch.object(bdd_api, "_post_multipart") as mock_multipart:
+            mock_multipart.side_effect = TestRailAuthenticationError(
+                "Authentication failed"
+            )
+
+            with pytest.raises(
+                TestRailAuthenticationError, match="Authentication failed"
+            ):
+                bdd_api.add_bdd(
+                    section_id=1, feature_file="/path/to/feature.feature"
+                )
+
+    def test_add_bdd_rate_limit_error(self, bdd_api: BDDAPI) -> None:
+        """Test add_bdd propagates rate limit errors."""
+        with patch.object(bdd_api, "_post_multipart") as mock_multipart:
+            mock_multipart.side_effect = TestRailRateLimitError(
+                "Rate limit exceeded"
+            )
+
+            with pytest.raises(
+                TestRailRateLimitError, match="Rate limit exceeded"
+            ):
+                bdd_api.add_bdd(
+                    section_id=1, feature_file="/path/to/feature.feature"
+                )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,9 +5,13 @@ This module contains comprehensive tests for the TestRailAPI class,
 including initialization, validation, and submodule setup.
 """
 
+import subprocess
+import sys
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
+import requests
 
 from testrail_api_module import (
     TestRailAPI,
@@ -273,3 +277,118 @@ class TestTestRailAPI:
                 api_key=None,
                 password=None,
             )
+
+    def test_init_creates_shared_session(self) -> None:
+        """Test TestRailAPI creates a single shared requests.Session."""
+        api = TestRailAPI(
+            base_url="https://testrail.example.com",
+            username="testuser@example.com",
+            api_key="test_api_key",
+        )
+
+        assert isinstance(api.session, requests.Session)
+        api.close()
+
+    def test_submodules_share_client_session(self) -> None:
+        """Test all submodules reuse the client's session (one
+        connection pool per client, not 24)."""
+        api = TestRailAPI(
+            base_url="https://testrail.example.com",
+            username="testuser@example.com",
+            api_key="test_api_key",
+        )
+
+        assert api.attachments.session is api.session
+        assert api.bdd.session is api.session
+        assert api.cases.session is api.session
+        assert api.results.session is api.session
+        assert api.runs.session is api.session
+        assert api.variables.session is api.session
+        api.close()
+
+    def test_close_closes_session(self) -> None:
+        """Test TestRailAPI.close() closes the shared session."""
+        api = TestRailAPI(
+            base_url="https://testrail.example.com",
+            username="testuser@example.com",
+            api_key="test_api_key",
+        )
+
+        with patch.object(api.session, "close") as mock_close:
+            api.close()
+
+        mock_close.assert_called_once_with()
+
+    def test_context_manager_returns_self(self) -> None:
+        """Test TestRailAPI.__enter__ returns the client itself."""
+        api = TestRailAPI(
+            base_url="https://testrail.example.com",
+            username="testuser@example.com",
+            api_key="test_api_key",
+        )
+
+        with api as entered:
+            assert entered is api
+
+    def test_context_manager_closes_on_exit(self) -> None:
+        """Test TestRailAPI.__exit__ closes the shared session."""
+        api = TestRailAPI(
+            base_url="https://testrail.example.com",
+            username="testuser@example.com",
+            api_key="test_api_key",
+        )
+
+        with patch.object(api, "close") as mock_close:
+            with api:
+                mock_close.assert_not_called()
+
+        mock_close.assert_called_once_with()
+
+    def test_context_manager_closes_on_exception(self) -> None:
+        """Test TestRailAPI.__exit__ closes the session on errors and
+        does not suppress the exception."""
+        api = TestRailAPI(
+            base_url="https://testrail.example.com",
+            username="testuser@example.com",
+            api_key="test_api_key",
+        )
+
+        with patch.object(api, "close") as mock_close:
+            with pytest.raises(RuntimeError, match="boom"):
+                with api:
+                    raise RuntimeError("boom")
+
+        mock_close.assert_called_once_with()
+
+    def test_submodules_importable_without_instantiation(self) -> None:
+        """Test submodules are reachable right after a fresh import,
+        without constructing a TestRailAPI client first."""
+        code = (
+            "import testrail_api_module as t; "
+            "assert t.cases.CasesAPI; "
+            "assert t.attachments.AttachmentsAPI; "
+            "assert t.variables.VariablesAPI"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_import_under_python_oo(self) -> None:
+        """Test the package imports under `python -OO` (docstrings are
+        stripped, so __doc__ is None and must not be .format()ed)."""
+        result = subprocess.run(
+            [sys.executable, "-OO", "-c", "import testrail_api_module"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_version_attribute(self) -> None:
+        """Test __version__ is exposed as a non-empty string."""
+        import testrail_api_module
+
+        assert isinstance(testrail_api_module.__version__, str)
+        assert testrail_api_module.__version__


### PR DESCRIPTION
## Summary

Single transport-layer PR fixing six audit findings in `base.py`, `__init__.py(.pyi)`, `attachments.py`, and `bdd.py`.

### #134 — query-param serialization
`_build_url` now serializes values centrally: booleans become `1`/`0` (previously `str(True)` sent `is_completed=True`, which PHP's `intval("True")` evaluates to 0 — silently **inverting** the filter), and lists/tuples are comma-joined (previously sent as Python reprs like `[1, 2]`). Pre-joined string filters in `results.py`/`tests.py` pass through unchanged (joining is only applied to list/tuple values), and booleans nested inside lists are also rendered as `1`/`0`.

### #135 — retry semantics
The session now uses a `Retry` subclass (`_TestRailRetry`) with `allowed_methods=None` and `raise_on_status=False`, so the final response after exhausted retries always flows into `_handle_response` — restoring the `429 → TestRailRateLimitError` contract for GETs and preserving `status_code`/`response_text` on 5xx failures (previously GETs raised urllib3 `RetryError` wrapped as a generic `TestRailAPIException`).

**POST retry safety:** TestRail performs *all* writes (including deletes) via POST and they are not idempotent. A plain `allowed_methods=None` would have replayed POSTs on 5xx and read errors, risking duplicate writes. urllib3's `Retry` cannot express per-method status lists declaratively, so `_TestRailRetry` overrides `is_retry` (POSTs retry **only** on 429, where the server refused the request without acting on it) and `_is_method_retryable` (POST read errors — request may have reached the server — are never replayed). POSTs still retry on connection errors, which never reach the server. Retries stay at 3 with backoff factor 1.

### #136 — session lifecycle
`TestRailAPI` now creates **one** shared `requests.Session`; all 24 submodules reuse it via `BaseAPI` (previously 24 independent, never-closed sessions per client). `BaseAPI` falls back to creating its own configured session only when used standalone without a `TestRailAPI` client. Added `TestRailAPI.close()` and context-manager support (`with TestRailAPI(...) as api:`).

### #137 — response handling (supersedes #99)
`_handle_response` accepts **all** 2xx statuses as success (previously only 200; 201/204 raised "Unexpected response status"). The `{}` return for empty bodies on POST-based deletes is preserved. A new `raw=True` parameter through `_api_request`/`_get` returns `response.content` bytes for binary endpoints, which previously could never succeed against the JSON-only handler.

### #138 — attachments + BDD rewrite
- Removed the fabricated generic `get_attachments(entity_type, entity_id)` / `add_attachment(entity_type, entity_id, file_path)`: they called endpoints that do not exist in any TestRail version (`add_attachment/case/1`) and sent the local file *path* as JSON. **These methods could never succeed against any TestRail instance, so their removal is not a practical breaking change.**
- Implemented the official surface: `add_attachment_to_case/plan/plan_entry/result/run`, `get_attachments_for_case/plan/plan_entry/run/test` (with `limit`/`offset` where the API supports them), `get_attachment` (raw bytes), `delete_attachment`. Attachment IDs widened to `int | str` (newer TestRail uses UUID strings).
- Uploads are real `multipart/form-data` via a new `BaseAPI._post_multipart(endpoint, file_path)`: the file is opened and streamed in an `attachment` form field with no JSON Content-Type header.
- `bdd.add_bdd` switched to the same multipart `attachment` upload and the undocumented `description` field was dropped; `get_bdd` returns the raw `.feature` bytes. The multipart format for `add_bdd` was verified against Gurock's official TestRail CLI ([gurock/trcli `bdd_handler.py`](https://github.com/gurock/trcli/blob/main/trcli/api/bdd_handler.py)), which posts `files={"attachment": ("feature.feature", content, "text/plain")}` to `add_bdd/{section_id}`.

### #139 — package core
- `__doc__.format(...)` guarded with `if __doc__:` — package now imports under `python -OO` (regression-tested via subprocess).
- Submodule imports moved from inside `TestRailAPI.__init__` to module level, so `testrail_api_module.cases` etc. exist immediately after import (no circular-import risk: submodules import only `.base`).
- `__init__.pyi` rewritten: all 24 submodule attributes typed concretely (`cases: CasesAPI`, ...), `base_url: str` / `api_key: str | None` / `timeout: int` / `session: requests.Session`, full 29-name `__all__` restored with `from . import x as x` re-exports, `__version__: str` / `__author__: str` added. `base.pyi` updated to match (`status_code: int | None`, `logger: logging.Logger`, `session: requests.Session`, overloaded `raw` signatures, `_post_multipart`). Verified with mypy: `api.cases` reveals `CasesAPI`, `api.attachments.get_attachment(1)` reveals `bytes`.

> Note: README examples still reference the removed generic attachment methods; README is intentionally untouched here (docs sweep is separate scope).

## Test plan

- `uv run pytest -q` — **464 passed** (was 418): new tests for bool/list/tuple serialization (incl. pre-joined-string passthrough and bools inside lists), 201/204 acceptance, raw bytes path (handler + `_api_request` + `_get` passthrough), multipart upload at session level (form field, no JSON header, auth, FileNotFoundError, 401/429/exception mapping), retry policy (GET vs POST matrices, `increment()` class preservation, adapter config), session sharing (BaseAPI fallback + all submodules share `api.session`), `close()`/context manager (incl. exception path), fresh-subprocess module-level importability, and `python -OO` import regression.
- `uv run mypy src/` — clean (26 files).
- `uv run ruff check src/ tests/` + `ruff format` on all touched files — clean.
- All pre-commit hooks (ruff, mypy, bandit, detect-secrets, ...) passed on commit.

## Sequencing

**Merge before module-parity PRs** — they will build on the corrected transport layer (`_post_multipart`, `raw=True`, central param serialization).

Closes #134
Closes #135
Closes #136
Closes #137
Closes #138
Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)