### PR TITLE
fix: runs and plans payload/endpoint parity (update_run case selection, plan-entry run management)

### DIFF
--- a/src/testrail_api_module/plans.py
+++ b/src/testrail_api_module/plans.py
@@ -34,20 +34,61 @@ class PlansAPI(BaseAPI):
         """
         return self._api_request("GET", f"get_plan/{plan_id}")
 
-    def get_plans(self, project_id: int) -> list[dict[str, Any]]:
+    def get_plans(
+        self,
+        project_id: int,
+        created_after: int | None = None,
+        created_before: int | None = None,
+        created_by: int | None = None,
+        is_completed: bool | None = None,
+        milestone_id: int | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> dict[str, Any]:
         """
         Get all test plans for a project.
 
         Args:
             project_id: The ID of the project to get test plans for.
+            created_after: Optional timestamp to filter plans created
+                after this time.
+            created_before: Optional timestamp to filter plans created
+                before this time.
+            created_by: Optional user ID to filter plans created by a
+                specific user.
+            is_completed: Optional boolean to filter by completion
+                status.
+            milestone_id: Optional milestone ID to filter plans by.
+            limit: Optional limit on number of results to return.
+            offset: Optional offset for pagination.
 
         Returns:
-            List of dictionaries containing test plan data.
+            Dict containing the pagination envelope with keys
+            ``offset``, ``limit``, ``size``, ``_links``, and ``plans``
+            (the list of test plan dicts).
 
         Raises:
             TestRailAPIError: If the API request fails.
         """
-        return self._api_request("GET", f"get_plans/{project_id}")
+        params = {}
+        if created_after is not None:
+            params["created_after"] = created_after
+        if created_before is not None:
+            params["created_before"] = created_before
+        if created_by is not None:
+            params["created_by"] = created_by
+        if is_completed is not None:
+            params["is_completed"] = is_completed
+        if milestone_id is not None:
+            params["milestone_id"] = milestone_id
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        return self._api_request(
+            "GET", f"get_plans/{project_id}", params=params
+        )
 
     def add_plan(
         self,
@@ -157,7 +198,8 @@ class PlansAPI(BaseAPI):
             description: Optional description of the test run.
             assignedto_id: Optional ID of the user to assign to.
             include_all: Whether to include all test cases
-                (default True).
+                (default True). Always sent explicitly in the
+                payload, mirroring add_run.
             case_ids: Optional list of case IDs to include.
             config_ids: Optional list of configuration IDs.
             runs: Optional list of run objects for multi-config
@@ -169,15 +211,16 @@ class PlansAPI(BaseAPI):
         Raises:
             TestRailAPIError: If the API request fails.
         """
-        data: dict[str, Any] = {"suite_id": suite_id}
+        data: dict[str, Any] = {
+            "suite_id": suite_id,
+            "include_all": include_all,
+        }
         if name is not None:
             data["name"] = name
         if description is not None:
             data["description"] = description
         if assignedto_id is not None:
             data["assignedto_id"] = assignedto_id
-        if not include_all:
-            data["include_all"] = include_all
         if case_ids is not None:
             data["case_ids"] = case_ids
         if config_ids is not None:
@@ -230,4 +273,128 @@ class PlansAPI(BaseAPI):
         return self._api_request(
             "POST",
             f"delete_plan_entry/{plan_id}/{entry_id}",
+        )
+
+    def add_run_to_plan_entry(
+        self,
+        plan_id: int,
+        entry_id: str,
+        config_ids: list[int],
+        description: str | None = None,
+        assignedto_id: int | None = None,
+        include_all: bool = True,
+        case_ids: list[int] | None = None,
+        refs: str | None = None,
+    ) -> dict[str, Any]:
+        """
+        Add a new test run to a plan entry that uses configurations.
+
+        Requires TestRail 6.4 or later.
+
+        Args:
+            plan_id: The ID of the test plan.
+            entry_id: The ID of the plan entry to add the run to.
+            config_ids: List of configuration IDs for the new run
+                (required).
+            description: Optional description of the test run.
+            assignedto_id: Optional ID of the user to assign to.
+            include_all: Whether to include all test cases
+                (default True). Always sent explicitly in the
+                payload, mirroring add_run.
+            case_ids: Optional list of case IDs to include.
+            refs: Optional comma-separated list of references.
+
+        Returns:
+            Dict containing the updated plan entry data (same format
+            as the entries field of get_plan, for a single entry).
+
+        Raises:
+            TestRailAPIError: If the API request fails.
+        """
+        data: dict[str, Any] = {
+            "config_ids": config_ids,
+            "include_all": include_all,
+        }
+        if description is not None:
+            data["description"] = description
+        if assignedto_id is not None:
+            data["assignedto_id"] = assignedto_id
+        if case_ids is not None:
+            data["case_ids"] = case_ids
+        if refs is not None:
+            data["refs"] = refs
+
+        return self._api_request(
+            "POST",
+            f"add_run_to_plan_entry/{plan_id}/{entry_id}",
+            data=data,
+        )
+
+    def update_run_in_plan_entry(
+        self,
+        run_id: int,
+        description: str | None = None,
+        assignedto_id: int | None = None,
+        include_all: bool | None = None,
+        case_ids: list[int] | None = None,
+        refs: str | None = None,
+    ) -> dict[str, Any]:
+        """
+        Update a test run inside a plan entry that uses
+        configurations.
+
+        Requires TestRail 6.4 or later. Only fields that are provided
+        (not None) are sent, so partial updates are supported.
+
+        Args:
+            run_id: The ID of the test run to update.
+            description: Optional new description of the test run.
+            assignedto_id: Optional ID of the user to assign to.
+            include_all: Optional flag to include all test cases
+                (set False and pass case_ids for a custom selection).
+            case_ids: Optional list of case IDs to include.
+            refs: Optional comma-separated list of references.
+
+        Returns:
+            Dict containing the updated test run data.
+
+        Raises:
+            TestRailAPIError: If the API request fails.
+        """
+        data: dict[str, Any] = {}
+        if description is not None:
+            data["description"] = description
+        if assignedto_id is not None:
+            data["assignedto_id"] = assignedto_id
+        if include_all is not None:
+            data["include_all"] = include_all
+        if case_ids is not None:
+            data["case_ids"] = case_ids
+        if refs is not None:
+            data["refs"] = refs
+
+        return self._api_request(
+            "POST",
+            f"update_run_in_plan_entry/{run_id}",
+            data=data,
+        )
+
+    def delete_run_from_plan_entry(self, run_id: int) -> dict[str, Any]:
+        """
+        Delete a test run from a plan entry that uses configurations.
+
+        Requires TestRail 6.4 or later.
+
+        Args:
+            run_id: The ID of the test run to delete.
+
+        Returns:
+            Dict containing the response data.
+
+        Raises:
+            TestRailAPIError: If the API request fails.
+        """
+        return self._api_request(
+            "POST",
+            f"delete_run_from_plan_entry/{run_id}",
         )

--- a/src/testrail_api_module/plans.pyi
+++ b/src/testrail_api_module/plans.pyi
@@ -4,7 +4,17 @@ from .base import BaseAPI as BaseAPI
 
 class PlansAPI(BaseAPI):
     def get_plan(self, plan_id: int) -> dict[str, Any]: ...
-    def get_plans(self, project_id: int) -> list[dict[str, Any]]: ...
+    def get_plans(
+        self,
+        project_id: int,
+        created_after: int | None = ...,
+        created_before: int | None = ...,
+        created_by: int | None = ...,
+        is_completed: bool | None = ...,
+        milestone_id: int | None = ...,
+        limit: int | None = ...,
+        offset: int | None = ...,
+    ) -> dict[str, Any]: ...
     def add_plan(
         self,
         project_id: int,
@@ -34,3 +44,24 @@ class PlansAPI(BaseAPI):
     def delete_plan_entry(
         self, plan_id: int, entry_id: str
     ) -> dict[str, Any]: ...
+    def add_run_to_plan_entry(
+        self,
+        plan_id: int,
+        entry_id: str,
+        config_ids: list[int],
+        description: str | None = ...,
+        assignedto_id: int | None = ...,
+        include_all: bool = ...,
+        case_ids: list[int] | None = ...,
+        refs: str | None = ...,
+    ) -> dict[str, Any]: ...
+    def update_run_in_plan_entry(
+        self,
+        run_id: int,
+        description: str | None = ...,
+        assignedto_id: int | None = ...,
+        include_all: bool | None = ...,
+        case_ids: list[int] | None = ...,
+        refs: str | None = ...,
+    ) -> dict[str, Any]: ...
+    def delete_run_from_plan_entry(self, run_id: int) -> dict[str, Any]: ...

--- a/src/testrail_api_module/runs.py
+++ b/src/testrail_api_module/runs.py
@@ -45,9 +45,10 @@ class RunsAPI(BaseAPI):
         created_before: int | None = None,
         created_by: int | None = None,
         is_completed: bool | None = None,
+        milestone_id: int | None = None,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> list[dict[str, Any]]:
+    ) -> dict[str, Any]:
         """
         Get all test runs for a project and optionally a specific suite.
 
@@ -58,18 +59,21 @@ class RunsAPI(BaseAPI):
             created_before: Optional timestamp to filter runs created before this time.
             created_by: Optional user ID to filter runs created by specific user.
             is_completed: Optional boolean to filter by completion status.
+            milestone_id: Optional milestone ID to filter runs by.
             limit: Optional limit on number of results to return.
             offset: Optional offset for pagination.
 
         Returns:
-            List of dictionaries containing test run data.
+            Dict containing the pagination envelope with keys
+            ``offset``, ``limit``, ``size``, ``_links``, and ``runs``
+            (the list of test run dicts).
 
         Raises:
             TestRailAPIError: If the API request fails.
 
         Example:
-            >>> runs = api.runs.get_runs(project_id=1, suite_id=2)
-            >>> for run in runs:
+            >>> response = api.runs.get_runs(project_id=1, suite_id=2)
+            >>> for run in response["runs"]:
             ...     print(f"Run: {run['name']}")
         """
         params = {}
@@ -83,6 +87,8 @@ class RunsAPI(BaseAPI):
             params["created_by"] = created_by
         if is_completed is not None:
             params["is_completed"] = is_completed
+        if milestone_id is not None:
+            params["milestone_id"] = milestone_id
         if limit is not None:
             params["limit"] = limit
         if offset is not None:
@@ -100,6 +106,7 @@ class RunsAPI(BaseAPI):
         assignedto_id: int | None = None,
         include_all: bool = True,
         case_ids: list[int] | None = None,
+        refs: str | None = None,
     ) -> dict[str, Any]:
         """
         Add a new test run.
@@ -113,6 +120,8 @@ class RunsAPI(BaseAPI):
             assignedto_id: Optional ID of the user to assign the test run to.
             include_all: Whether to include all test cases from the suite.
             case_ids: Optional list of test case IDs to include in the run.
+            refs: Optional comma-separated list of references
+                (requires TestRail 6.1+).
 
         Returns:
             Dict containing the created test run data.
@@ -138,6 +147,7 @@ class RunsAPI(BaseAPI):
             "milestone_id": milestone_id,
             "assignedto_id": assignedto_id,
             "case_ids": case_ids,
+            "refs": refs,
         }
 
         for field, value in optional_fields.items():
@@ -153,9 +163,16 @@ class RunsAPI(BaseAPI):
         description: str | None = None,
         milestone_id: int | None = None,
         assignedto_id: int | None = None,
+        include_all: bool | None = None,
+        case_ids: list[int] | None = None,
+        refs: str | None = None,
     ) -> dict[str, Any]:
         """
         Update a test run.
+
+        Supports the same fields as :meth:`add_run` minus ``suite_id``.
+        Only fields that are provided (not None) are sent, so partial
+        updates are supported.
 
         Args:
             run_id: The ID of the test run to update.
@@ -163,6 +180,13 @@ class RunsAPI(BaseAPI):
             description: Optional new description for the test run.
             milestone_id: Optional new milestone ID.
             assignedto_id: Optional new assigned user ID.
+            include_all: Optional flag to include all test cases from
+                the suite (set False and pass case_ids to select a
+                custom case selection).
+            case_ids: Optional list of test case IDs to include in
+                the run.
+            refs: Optional comma-separated list of references
+                (requires TestRail 6.1+).
 
         Returns:
             Dict containing the updated test run data.
@@ -174,7 +198,8 @@ class RunsAPI(BaseAPI):
             >>> updated_run = api.runs.update_run(
             ...     run_id=123,
             ...     name="Updated Run Name",
-            ...     assignedto_id=456
+            ...     include_all=False,
+            ...     case_ids=[1, 2, 3]
             ... )
         """
         data = {}
@@ -185,6 +210,9 @@ class RunsAPI(BaseAPI):
             "description": description,
             "milestone_id": milestone_id,
             "assignedto_id": assignedto_id,
+            "include_all": include_all,
+            "case_ids": case_ids,
+            "refs": refs,
         }
 
         for field, value in optional_fields.items():

--- a/src/testrail_api_module/runs.pyi
+++ b/src/testrail_api_module/runs.pyi
@@ -36,9 +36,10 @@ class RunsAPI(BaseAPI):
         created_before: int | None = None,
         created_by: int | None = None,
         is_completed: bool | None = None,
+        milestone_id: int | None = None,
         limit: int | None = None,
         offset: int | None = None,
-    ) -> list[dict[str, Any]]:
+    ) -> dict[str, Any]:
         """
         Get all test runs for a project and optionally a specific suite.
 
@@ -49,18 +50,21 @@ class RunsAPI(BaseAPI):
             created_before: Optional timestamp to filter runs created before this time.
             created_by: Optional user ID to filter runs created by specific user.
             is_completed: Optional boolean to filter by completion status.
+            milestone_id: Optional milestone ID to filter runs by.
             limit: Optional limit on number of results to return.
             offset: Optional offset for pagination.
 
         Returns:
-            List of dictionaries containing test run data.
+            Dict containing the pagination envelope with keys
+            ``offset``, ``limit``, ``size``, ``_links``, and ``runs``
+            (the list of test run dicts).
 
         Raises:
             TestRailAPIError: If the API request fails.
 
         Example:
-            >>> runs = api.runs.get_runs(project_id=1, suite_id=2)
-            >>> for run in runs:
+            >>> response = api.runs.get_runs(project_id=1, suite_id=2)
+            >>> for run in response["runs"]:
             ...     print(f"Run: {run[\'name\']}")
         """
     def add_run(
@@ -73,6 +77,7 @@ class RunsAPI(BaseAPI):
         assignedto_id: int | None = None,
         include_all: bool = True,
         case_ids: list[int] | None = None,
+        refs: str | None = None,
     ) -> dict[str, Any]:
         """
         Add a new test run.
@@ -86,6 +91,8 @@ class RunsAPI(BaseAPI):
             assignedto_id: Optional ID of the user to assign the test run to.
             include_all: Whether to include all test cases from the suite.
             case_ids: Optional list of test case IDs to include in the run.
+            refs: Optional comma-separated list of references
+                (requires TestRail 6.1+).
 
         Returns:
             Dict containing the created test run data.
@@ -109,9 +116,16 @@ class RunsAPI(BaseAPI):
         description: str | None = None,
         milestone_id: int | None = None,
         assignedto_id: int | None = None,
+        include_all: bool | None = None,
+        case_ids: list[int] | None = None,
+        refs: str | None = None,
     ) -> dict[str, Any]:
         """
         Update a test run.
+
+        Supports the same fields as :meth:`add_run` minus ``suite_id``.
+        Only fields that are provided (not None) are sent, so partial
+        updates are supported.
 
         Args:
             run_id: The ID of the test run to update.
@@ -119,6 +133,13 @@ class RunsAPI(BaseAPI):
             description: Optional new description for the test run.
             milestone_id: Optional new milestone ID.
             assignedto_id: Optional new assigned user ID.
+            include_all: Optional flag to include all test cases from
+                the suite (set False and pass case_ids to select a
+                custom case selection).
+            case_ids: Optional list of test case IDs to include in
+                the run.
+            refs: Optional comma-separated list of references
+                (requires TestRail 6.1+).
 
         Returns:
             Dict containing the updated test run data.
@@ -130,7 +151,8 @@ class RunsAPI(BaseAPI):
             >>> updated_run = api.runs.update_run(
             ...     run_id=123,
             ...     name="Updated Run Name",
-            ...     assignedto_id=456
+            ...     include_all=False,
+            ...     case_ids=[1, 2, 3]
             ... )
         """
     def close_run(self, run_id: int) -> dict[str, Any]:

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -55,17 +55,92 @@ class TestPlansAPI:
             assert result == {"id": 1, "name": "Test Plan"}
 
     def test_get_plans(self, plans_api: PlansAPI) -> None:
-        """Test get_plans method."""
+        """Test get_plans with minimal required parameters."""
         with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.return_value = [
-                {"id": 1, "name": "Plan 1"},
-                {"id": 2, "name": "Plan 2"},
-            ]
+            envelope = {
+                "offset": 0,
+                "limit": 250,
+                "size": 2,
+                "_links": {"next": None, "prev": None},
+                "plans": [
+                    {"id": 1, "name": "Plan 1"},
+                    {"id": 2, "name": "Plan 2"},
+                ],
+            }
+            mock_request.return_value = envelope
 
             result = plans_api.get_plans(project_id=1)
 
-            mock_request.assert_called_once_with("GET", "get_plans/1")
-            assert len(result) == 2
+            mock_request.assert_called_once_with(
+                "GET", "get_plans/1", params={}
+            )
+            assert result == envelope
+            assert len(result["plans"]) == 2
+
+    def test_get_plans_with_all_parameters(self, plans_api: PlansAPI) -> None:
+        """Test get_plans with all optional filter parameters."""
+        with patch.object(plans_api, "_api_request") as mock_request:
+            envelope = {
+                "offset": 0,
+                "limit": 10,
+                "size": 1,
+                "_links": {"next": None, "prev": None},
+                "plans": [{"id": 1, "name": "Plan 1"}],
+            }
+            mock_request.return_value = envelope
+
+            result = plans_api.get_plans(
+                project_id=1,
+                created_after=1000000,
+                created_before=2000000,
+                created_by=3,
+                is_completed=True,
+                milestone_id=4,
+                limit=10,
+                offset=0,
+            )
+
+            expected_params = {
+                "created_after": 1000000,
+                "created_before": 2000000,
+                "created_by": 3,
+                "is_completed": True,
+                "milestone_id": 4,
+                "limit": 10,
+                "offset": 0,
+            }
+            mock_request.assert_called_once_with(
+                "GET", "get_plans/1", params=expected_params
+            )
+            assert result == envelope
+
+    def test_get_plans_with_none_values(self, plans_api: PlansAPI) -> None:
+        """Test get_plans with None values for optional parameters."""
+        with patch.object(plans_api, "_api_request") as mock_request:
+            envelope = {
+                "offset": 0,
+                "limit": 250,
+                "size": 1,
+                "_links": {"next": None, "prev": None},
+                "plans": [{"id": 1}],
+            }
+            mock_request.return_value = envelope
+
+            result = plans_api.get_plans(
+                project_id=1,
+                created_after=None,
+                created_before=None,
+                created_by=None,
+                is_completed=None,
+                milestone_id=None,
+                limit=None,
+                offset=None,
+            )
+
+            mock_request.assert_called_once_with(
+                "GET", "get_plans/1", params={}
+            )
+            assert result == envelope
 
     def test_add_plan_minimal(self, plans_api: PlansAPI) -> None:
         """Test add_plan with minimal required parameters."""
@@ -171,7 +246,7 @@ class TestPlansAPI:
 
             result = plans_api.add_plan_entry(plan_id=1, suite_id=5)
 
-            expected_data = {"suite_id": 5}
+            expected_data = {"suite_id": 5, "include_all": True}
             mock_request.assert_called_once_with(
                 "POST", "add_plan_entry/1", data=expected_data
             )
@@ -220,7 +295,7 @@ class TestPlansAPI:
         with patch.object(plans_api, "_api_request") as mock_request:
             mock_request.return_value = {"id": 10, "suite_id": 5}
 
-            plans_api.add_plan_entry(
+            result = plans_api.add_plan_entry(
                 plan_id=1,
                 suite_id=5,
                 name=None,
@@ -231,23 +306,58 @@ class TestPlansAPI:
                 runs=None,
             )
 
-            expected_data = {"suite_id": 5}
+            expected_data = {"suite_id": 5, "include_all": True}
             mock_request.assert_called_once_with(
                 "POST", "add_plan_entry/1", data=expected_data
             )
+            assert result == {"id": 10, "suite_id": 5}
 
-    def test_add_plan_entry_include_all_true_not_sent(
+    def test_add_plan_entry_include_all_true_sent(
         self, plans_api: PlansAPI
     ) -> None:
-        """Test add_plan_entry omits include_all when it is True (default)."""
+        """Test add_plan_entry always sends include_all, even when True.
+
+        Regression test for #101: include_all=True used to be silently
+        dropped from the payload.
+        """
         with patch.object(plans_api, "_api_request") as mock_request:
             mock_request.return_value = {"id": 10, "suite_id": 5}
 
-            plans_api.add_plan_entry(plan_id=1, suite_id=5, include_all=True)
+            result = plans_api.add_plan_entry(
+                plan_id=1, suite_id=5, include_all=True
+            )
 
             call_args = mock_request.call_args
             data_sent = call_args[1]["data"]
-            assert "include_all" not in data_sent
+            assert data_sent["include_all"] is True
+            mock_request.assert_called_once_with(
+                "POST",
+                "add_plan_entry/1",
+                data={"suite_id": 5, "include_all": True},
+            )
+            assert result == {"id": 10, "suite_id": 5}
+
+    def test_add_plan_entry_include_all_false_sent(
+        self, plans_api: PlansAPI
+    ) -> None:
+        """Test add_plan_entry sends include_all when it is False."""
+        with patch.object(plans_api, "_api_request") as mock_request:
+            mock_request.return_value = {"id": 10, "suite_id": 5}
+
+            result = plans_api.add_plan_entry(
+                plan_id=1, suite_id=5, include_all=False, case_ids=[1, 2]
+            )
+
+            mock_request.assert_called_once_with(
+                "POST",
+                "add_plan_entry/1",
+                data={
+                    "suite_id": 5,
+                    "include_all": False,
+                    "case_ids": [1, 2],
+                },
+            )
+            assert result == {"id": 10, "suite_id": 5}
 
     def test_update_plan_entry(self, plans_api: PlansAPI) -> None:
         """Test update_plan_entry with keyword arguments."""
@@ -302,6 +412,294 @@ class TestPlansAPI:
                 "POST", "delete_plan_entry/1/abc-123"
             )
             assert result == {}
+
+    def test_add_run_to_plan_entry_minimal(self, plans_api: PlansAPI) -> None:
+        """Test add_run_to_plan_entry with minimal required parameters."""
+        with patch.object(plans_api, "_api_request") as mock_request:
+            mock_request.return_value = {"id": "abc-123", "runs": []}
+
+            result = plans_api.add_run_to_plan_entry(
+                plan_id=1, entry_id="abc-123", config_ids=[1, 5]
+            )
+
+            expected_data = {"config_ids": [1, 5], "include_all": True}
+            mock_request.assert_called_once_with(
+                "POST",
+                "add_run_to_plan_entry/1/abc-123",
+                data=expected_data,
+            )
+            assert result == {"id": "abc-123", "runs": []}
+
+    def test_add_run_to_plan_entry_with_all_parameters(
+        self, plans_api: PlansAPI
+    ) -> None:
+        """Test add_run_to_plan_entry with all optional parameters."""
+        with patch.object(plans_api, "_api_request") as mock_request:
+            mock_request.return_value = {"id": "abc-123", "runs": []}
+
+            result = plans_api.add_run_to_plan_entry(
+                plan_id=1,
+                entry_id="abc-123",
+                config_ids=[1, 5],
+                description="Run description",
+                assignedto_id=3,
+                include_all=False,
+                case_ids=[1, 2, 4],
+                refs="JIRA-1",
+            )
+
+            expected_data = {
+                "config_ids": [1, 5],
+                "include_all": False,
+                "description": "Run description",
+                "assignedto_id": 3,
+                "case_ids": [1, 2, 4],
+                "refs": "JIRA-1",
+            }
+            mock_request.assert_called_once_with(
+                "POST",
+                "add_run_to_plan_entry/1/abc-123",
+                data=expected_data,
+            )
+            assert result == {"id": "abc-123", "runs": []}
+
+    def test_add_run_to_plan_entry_with_none_values(
+        self, plans_api: PlansAPI
+    ) -> None:
+        """Test add_run_to_plan_entry excludes None optional fields."""
+        with patch.object(plans_api, "_api_request") as mock_request:
+            mock_request.return_value = {"id": "abc-123", "runs": []}
+
+            result = plans_api.add_run_to_plan_entry(
+                plan_id=1,
+                entry_id="abc-123",
+                config_ids=[1],
+                description=None,
+                assignedto_id=None,
+                case_ids=None,
+                refs=None,
+            )
+
+            expected_data = {"config_ids": [1], "include_all": True}
+            mock_request.assert_called_once_with(
+                "POST",
+                "add_run_to_plan_entry/1/abc-123",
+                data=expected_data,
+            )
+            assert result == {"id": "abc-123", "runs": []}
+
+    def test_add_run_to_plan_entry_api_error(
+        self, plans_api: PlansAPI
+    ) -> None:
+        """Test add_run_to_plan_entry raises TestRailAPIError."""
+        with patch.object(plans_api, "_api_request") as mock_request:
+            mock_request.side_effect = TestRailAPIError("API request failed")
+
+            with pytest.raises(TestRailAPIError, match="API request failed"):
+                plans_api.add_run_to_plan_entry(
+                    plan_id=1, entry_id="abc-123", config_ids=[1]
+                )
+
+    def test_add_run_to_plan_entry_authentication_error(
+        self, plans_api: PlansAPI
+    ) -> None:
+        """Test add_run_to_plan_entry raises authentication error."""
+        with patch.object(plans_api, "_api_request") as mock_request:
+            mock_request.side_effect = TestRailAuthenticationError(
+                "Authentication failed"
+            )
+
+            with pytest.raises(
+                TestRailAuthenticationError, match="Authentication failed"
+            ):
+                plans_api.add_run_to_plan_entry(
+                    plan_id=1, entry_id="abc-123", config_ids=[1]
+                )
+
+    def test_add_run_to_plan_entry_rate_limit_error(
+        self, plans_api: PlansAPI
+    ) -> None:
+        """Test add_run_to_plan_entry raises rate limit error."""
+        with patch.object(plans_api, "_api_request") as mock_request:
+            mock_request.side_effect = TestRailRateLimitError(
+                "Rate limit exceeded"
+            )
+
+            with pytest.raises(
+                TestRailRateLimitError, match="Rate limit exceeded"
+            ):
+                plans_api.add_run_to_plan_entry(
+                    plan_id=1, entry_id="abc-123", config_ids=[1]
+                )
+
+    def test_update_run_in_plan_entry_minimal(
+        self, plans_api: PlansAPI
+    ) -> None:
+        """Test update_run_in_plan_entry with only run_id."""
+        with patch.object(plans_api, "_api_request") as mock_request:
+            mock_request.return_value = {"id": 81}
+
+            result = plans_api.update_run_in_plan_entry(run_id=81)
+
+            mock_request.assert_called_once_with(
+                "POST", "update_run_in_plan_entry/81", data={}
+            )
+            assert result == {"id": 81}
+
+    def test_update_run_in_plan_entry_with_all_parameters(
+        self, plans_api: PlansAPI
+    ) -> None:
+        """Test update_run_in_plan_entry with all optional parameters."""
+        with patch.object(plans_api, "_api_request") as mock_request:
+            mock_request.return_value = {"id": 81, "include_all": False}
+
+            result = plans_api.update_run_in_plan_entry(
+                run_id=81,
+                description="Updated description",
+                assignedto_id=3,
+                include_all=False,
+                case_ids=[1, 2, 4],
+                refs="JIRA-2",
+            )
+
+            expected_data = {
+                "description": "Updated description",
+                "assignedto_id": 3,
+                "include_all": False,
+                "case_ids": [1, 2, 4],
+                "refs": "JIRA-2",
+            }
+            mock_request.assert_called_once_with(
+                "POST", "update_run_in_plan_entry/81", data=expected_data
+            )
+            assert result == {"id": 81, "include_all": False}
+
+    def test_update_run_in_plan_entry_with_none_values(
+        self, plans_api: PlansAPI
+    ) -> None:
+        """Test update_run_in_plan_entry excludes None fields."""
+        with patch.object(plans_api, "_api_request") as mock_request:
+            mock_request.return_value = {"id": 81}
+
+            result = plans_api.update_run_in_plan_entry(
+                run_id=81,
+                description=None,
+                assignedto_id=None,
+                include_all=None,
+                case_ids=None,
+                refs=None,
+            )
+
+            mock_request.assert_called_once_with(
+                "POST", "update_run_in_plan_entry/81", data={}
+            )
+            assert result == {"id": 81}
+
+    def test_update_run_in_plan_entry_include_all_true_sent(
+        self, plans_api: PlansAPI
+    ) -> None:
+        """Test update_run_in_plan_entry sends include_all when True."""
+        with patch.object(plans_api, "_api_request") as mock_request:
+            mock_request.return_value = {"id": 81, "include_all": True}
+
+            result = plans_api.update_run_in_plan_entry(
+                run_id=81, include_all=True
+            )
+
+            mock_request.assert_called_once_with(
+                "POST",
+                "update_run_in_plan_entry/81",
+                data={"include_all": True},
+            )
+            assert result == {"id": 81, "include_all": True}
+
+    def test_update_run_in_plan_entry_api_error(
+        self, plans_api: PlansAPI
+    ) -> None:
+        """Test update_run_in_plan_entry raises TestRailAPIError."""
+        with patch.object(plans_api, "_api_request") as mock_request:
+            mock_request.side_effect = TestRailAPIError("API request failed")
+
+            with pytest.raises(TestRailAPIError, match="API request failed"):
+                plans_api.update_run_in_plan_entry(run_id=81)
+
+    def test_update_run_in_plan_entry_authentication_error(
+        self, plans_api: PlansAPI
+    ) -> None:
+        """Test update_run_in_plan_entry raises authentication error."""
+        with patch.object(plans_api, "_api_request") as mock_request:
+            mock_request.side_effect = TestRailAuthenticationError(
+                "Authentication failed"
+            )
+
+            with pytest.raises(
+                TestRailAuthenticationError, match="Authentication failed"
+            ):
+                plans_api.update_run_in_plan_entry(run_id=81)
+
+    def test_update_run_in_plan_entry_rate_limit_error(
+        self, plans_api: PlansAPI
+    ) -> None:
+        """Test update_run_in_plan_entry raises rate limit error."""
+        with patch.object(plans_api, "_api_request") as mock_request:
+            mock_request.side_effect = TestRailRateLimitError(
+                "Rate limit exceeded"
+            )
+
+            with pytest.raises(
+                TestRailRateLimitError, match="Rate limit exceeded"
+            ):
+                plans_api.update_run_in_plan_entry(run_id=81)
+
+    def test_delete_run_from_plan_entry(self, plans_api: PlansAPI) -> None:
+        """Test delete_run_from_plan_entry sends POST to the endpoint."""
+        with patch.object(plans_api, "_api_request") as mock_request:
+            mock_request.return_value = {}
+
+            result = plans_api.delete_run_from_plan_entry(run_id=81)
+
+            mock_request.assert_called_once_with(
+                "POST", "delete_run_from_plan_entry/81"
+            )
+            assert result == {}
+
+    def test_delete_run_from_plan_entry_api_error(
+        self, plans_api: PlansAPI
+    ) -> None:
+        """Test delete_run_from_plan_entry raises TestRailAPIError."""
+        with patch.object(plans_api, "_api_request") as mock_request:
+            mock_request.side_effect = TestRailAPIError("API request failed")
+
+            with pytest.raises(TestRailAPIError, match="API request failed"):
+                plans_api.delete_run_from_plan_entry(run_id=81)
+
+    def test_delete_run_from_plan_entry_authentication_error(
+        self, plans_api: PlansAPI
+    ) -> None:
+        """Test delete_run_from_plan_entry raises authentication error."""
+        with patch.object(plans_api, "_api_request") as mock_request:
+            mock_request.side_effect = TestRailAuthenticationError(
+                "Authentication failed"
+            )
+
+            with pytest.raises(
+                TestRailAuthenticationError, match="Authentication failed"
+            ):
+                plans_api.delete_run_from_plan_entry(run_id=81)
+
+    def test_delete_run_from_plan_entry_rate_limit_error(
+        self, plans_api: PlansAPI
+    ) -> None:
+        """Test delete_run_from_plan_entry raises rate limit error."""
+        with patch.object(plans_api, "_api_request") as mock_request:
+            mock_request.side_effect = TestRailRateLimitError(
+                "Rate limit exceeded"
+            )
+
+            with pytest.raises(
+                TestRailRateLimitError, match="Rate limit exceeded"
+            ):
+                plans_api.delete_run_from_plan_entry(run_id=81)
 
     def test_api_request_failure(self, plans_api: PlansAPI) -> None:
         """Test behavior when API request fails."""

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -56,29 +56,45 @@ class TestRunsAPI:
     def test_get_runs_minimal(self, runs_api: RunsAPI) -> None:
         """Test get_runs with minimal required parameters."""
         with patch.object(runs_api, "_get") as mock_get:
-            mock_get.return_value = [
-                {"id": 1, "name": "Run 1"},
-                {"id": 2, "name": "Run 2"},
-            ]
+            envelope = {
+                "offset": 0,
+                "limit": 250,
+                "size": 2,
+                "_links": {"next": None, "prev": None},
+                "runs": [
+                    {"id": 1, "name": "Run 1"},
+                    {"id": 2, "name": "Run 2"},
+                ],
+            }
+            mock_get.return_value = envelope
 
             result = runs_api.get_runs(project_id=1)
 
             mock_get.assert_called_once_with("get_runs/1", params={})
-            assert len(result) == 2
-            assert result[0]["id"] == 1
+            assert result == envelope
+            assert len(result["runs"]) == 2
+            assert result["runs"][0]["id"] == 1
 
     def test_get_runs_with_all_parameters(self, runs_api: RunsAPI) -> None:
         """Test get_runs with all optional parameters."""
         with patch.object(runs_api, "_get") as mock_get:
-            mock_get.return_value = [{"id": 1, "name": "Run 1"}]
+            envelope = {
+                "offset": 0,
+                "limit": 10,
+                "size": 1,
+                "_links": {"next": None, "prev": None},
+                "runs": [{"id": 1, "name": "Run 1"}],
+            }
+            mock_get.return_value = envelope
 
-            runs_api.get_runs(
+            result = runs_api.get_runs(
                 project_id=1,
                 suite_id=2,
                 created_after=1000000,
                 created_before=2000000,
                 created_by=1,
                 is_completed=True,
+                milestone_id=5,
                 limit=10,
                 offset=0,
             )
@@ -89,30 +105,62 @@ class TestRunsAPI:
                 "created_before": 2000000,
                 "created_by": 1,
                 "is_completed": True,
+                "milestone_id": 5,
                 "limit": 10,
                 "offset": 0,
             }
             mock_get.assert_called_once_with(
                 "get_runs/1", params=expected_params
             )
+            assert result == envelope
 
     def test_get_runs_with_none_values(self, runs_api: RunsAPI) -> None:
         """Test get_runs with None values for optional parameters."""
         with patch.object(runs_api, "_get") as mock_get:
-            mock_get.return_value = [{"id": 1}]
+            envelope = {
+                "offset": 0,
+                "limit": 250,
+                "size": 1,
+                "_links": {"next": None, "prev": None},
+                "runs": [{"id": 1}],
+            }
+            mock_get.return_value = envelope
 
-            runs_api.get_runs(
+            result = runs_api.get_runs(
                 project_id=1,
                 suite_id=None,
                 created_after=None,
                 created_before=None,
                 created_by=None,
                 is_completed=None,
+                milestone_id=None,
                 limit=None,
                 offset=None,
             )
 
             mock_get.assert_called_once_with("get_runs/1", params={})
+            assert result == envelope
+
+    def test_get_runs_with_milestone_id_filter(
+        self, runs_api: RunsAPI
+    ) -> None:
+        """Test get_runs with only the milestone_id filter."""
+        with patch.object(runs_api, "_get") as mock_get:
+            envelope = {
+                "offset": 0,
+                "limit": 250,
+                "size": 1,
+                "_links": {"next": None, "prev": None},
+                "runs": [{"id": 1, "milestone_id": 7}],
+            }
+            mock_get.return_value = envelope
+
+            result = runs_api.get_runs(project_id=1, milestone_id=7)
+
+            mock_get.assert_called_once_with(
+                "get_runs/1", params={"milestone_id": 7}
+            )
+            assert result == envelope
 
     def test_add_run_minimal(self, runs_api: RunsAPI) -> None:
         """Test add_run with minimal required parameters."""
@@ -130,7 +178,7 @@ class TestRunsAPI:
         with patch.object(runs_api, "_post") as mock_post:
             mock_post.return_value = {"id": 1, "name": "Test Run"}
 
-            runs_api.add_run(
+            result = runs_api.add_run(
                 project_id=1,
                 name="Test Run",
                 description="Test description",
@@ -139,6 +187,7 @@ class TestRunsAPI:
                 assignedto_id=4,
                 include_all=False,
                 case_ids=[1, 2, 3],
+                refs="JIRA-1,JIRA-2",
             )
 
             expected_data = {
@@ -149,15 +198,17 @@ class TestRunsAPI:
                 "milestone_id": 3,
                 "assignedto_id": 4,
                 "case_ids": [1, 2, 3],
+                "refs": "JIRA-1,JIRA-2",
             }
             mock_post.assert_called_once_with("add_run/1", data=expected_data)
+            assert result == {"id": 1, "name": "Test Run"}
 
     def test_add_run_with_none_values(self, runs_api: RunsAPI) -> None:
         """Test add_run with None values for optional parameters."""
         with patch.object(runs_api, "_post") as mock_post:
             mock_post.return_value = {"id": 1, "name": "Test Run"}
 
-            runs_api.add_run(
+            result = runs_api.add_run(
                 project_id=1,
                 name="Test Run",
                 description=None,
@@ -165,10 +216,12 @@ class TestRunsAPI:
                 milestone_id=None,
                 assignedto_id=None,
                 case_ids=None,
+                refs=None,
             )
 
             expected_data = {"name": "Test Run", "include_all": True}
             mock_post.assert_called_once_with("add_run/1", data=expected_data)
+            assert result == {"id": 1, "name": "Test Run"}
 
     def test_update_run_minimal(self, runs_api: RunsAPI) -> None:
         """Test update_run with minimal parameters (only run_id)."""
@@ -188,12 +241,15 @@ class TestRunsAPI:
         with patch.object(runs_api, "_post") as mock_post:
             mock_post.return_value = {"id": 1, "name": "Updated Run"}
 
-            runs_api.update_run(
+            result = runs_api.update_run(
                 run_id=1,
                 name="Updated Run",
                 description="Updated description",
                 milestone_id=2,
                 assignedto_id=3,
+                include_all=False,
+                case_ids=[10, 20, 30],
+                refs="JIRA-9",
             )
 
             expected_data = {
@@ -201,28 +257,96 @@ class TestRunsAPI:
                 "description": "Updated description",
                 "milestone_id": 2,
                 "assignedto_id": 3,
+                "include_all": False,
+                "case_ids": [10, 20, 30],
+                "refs": "JIRA-9",
             }
             mock_post.assert_called_once_with(
                 "update_run/1", data=expected_data
             )
+            assert result == {"id": 1, "name": "Updated Run"}
 
     def test_update_run_with_none_values(self, runs_api: RunsAPI) -> None:
         """Test update_run with None values for optional parameters."""
         with patch.object(runs_api, "_post") as mock_post:
             mock_post.return_value = {"id": 1}
 
-            runs_api.update_run(
+            result = runs_api.update_run(
                 run_id=1,
                 name=None,
                 description=None,
                 milestone_id=None,
                 assignedto_id=None,
+                include_all=None,
+                case_ids=None,
+                refs=None,
             )
 
             expected_data = {}
             mock_post.assert_called_once_with(
                 "update_run/1", data=expected_data
             )
+            assert result == {"id": 1}
+
+    def test_update_run_change_case_selection(self, runs_api: RunsAPI) -> None:
+        """Test update_run can change the case selection of a run."""
+        with patch.object(runs_api, "_post") as mock_post:
+            mock_post.return_value = {"id": 1, "include_all": False}
+
+            result = runs_api.update_run(
+                run_id=1, include_all=False, case_ids=[1, 2, 4]
+            )
+
+            expected_data = {"include_all": False, "case_ids": [1, 2, 4]}
+            mock_post.assert_called_once_with(
+                "update_run/1", data=expected_data
+            )
+            assert result == {"id": 1, "include_all": False}
+
+    def test_update_run_include_all_true_sent(self, runs_api: RunsAPI) -> None:
+        """Test update_run sends include_all when explicitly True."""
+        with patch.object(runs_api, "_post") as mock_post:
+            mock_post.return_value = {"id": 1, "include_all": True}
+
+            result = runs_api.update_run(run_id=1, include_all=True)
+
+            expected_data = {"include_all": True}
+            mock_post.assert_called_once_with(
+                "update_run/1", data=expected_data
+            )
+            assert result == {"id": 1, "include_all": True}
+
+    def test_update_run_api_error(self, runs_api: RunsAPI) -> None:
+        """Test update_run raises TestRailAPIError on failure."""
+        with patch.object(runs_api, "_post") as mock_post:
+            mock_post.side_effect = TestRailAPIError("API request failed")
+
+            with pytest.raises(TestRailAPIError, match="API request failed"):
+                runs_api.update_run(run_id=1, name="Updated Run")
+
+    def test_update_run_authentication_error(self, runs_api: RunsAPI) -> None:
+        """Test update_run raises TestRailAuthenticationError on 401."""
+        with patch.object(runs_api, "_post") as mock_post:
+            mock_post.side_effect = TestRailAuthenticationError(
+                "Authentication failed"
+            )
+
+            with pytest.raises(
+                TestRailAuthenticationError, match="Authentication failed"
+            ):
+                runs_api.update_run(run_id=1, name="Updated Run")
+
+    def test_update_run_rate_limit_error(self, runs_api: RunsAPI) -> None:
+        """Test update_run raises TestRailRateLimitError on 429."""
+        with patch.object(runs_api, "_post") as mock_post:
+            mock_post.side_effect = TestRailRateLimitError(
+                "Rate limit exceeded"
+            )
+
+            with pytest.raises(
+                TestRailRateLimitError, match="Rate limit exceeded"
+            ):
+                runs_api.update_run(run_id=1, name="Updated Run")
 
     def test_close_run(self, runs_api: RunsAPI) -> None:
         """Test close_run method."""


### PR DESCRIPTION
## Summary

Brings `runs.py` and `plans.py` to parity with the official TestRail API and fixes the `add_plan_entry` `include_all` payload bug.

## Changes

### runs.py / runs.pyi

- **`update_run`**: added `include_all`, `case_ids`, and `refs` parameters (official docs: same fields as `add_run` minus `suite_id`). The case selection of an existing run can now be changed through the wrapper. Partial-update semantics preserved: only non-None fields are sent.
- **`add_run`**: added `refs` (TestRail 6.1+).
- **`get_runs`**: added `milestone_id` filter. Boolean serialization (`is_completed` etc.) deliberately untouched — #134 fixes that centrally in `_build_url`.
- **Pagination annotation fix**: `get_runs` return type corrected from `list[dict[str, Any]]` to `dict[str, Any]` — the API returns the envelope `{offset, limit, size, _links, runs}`. Docstring and stub updated; no runtime change.

### plans.py / plans.pyi

- **New endpoints** (TestRail 6.4+), previously individual runs inside multi-config plan entries could not be managed at all:
  - `add_run_to_plan_entry(plan_id, entry_id, config_ids, ...)` → POST `add_run_to_plan_entry/{plan_id}/{entry_id}` — `config_ids` required; optional `description`, `assignedto_id`, `include_all`, `case_ids`, `refs`
  - `update_run_in_plan_entry(run_id, ...)` → POST `update_run_in_plan_entry/{run_id}` — partial updates, only non-None fields sent
  - `delete_run_from_plan_entry(run_id)` → POST `delete_run_from_plan_entry/{run_id}`
- **`get_plans`**: added documented filters `created_after`, `created_before`, `created_by`, `is_completed`, `milestone_id`, `limit`, `offset`. Same pagination-envelope annotation fix (`{..., plans}`).
- **#101 fix — `add_plan_entry`**: previously used `if not include_all:` so `include_all=True` was silently dropped from the payload. Now always sends `include_all` explicitly, mirroring `add_run`. `update_plan_entry` was checked for the same bug class — it passes `**kwargs` straight through, so no change needed.

## Endpoint verification

Direct fetches of support.testrail.com 403, so fields were verified via WebSearch against the official docs:

- [Plans – TestRail Support Center](https://support.testrail.com/hc/en-us/articles/7077711537684-Plans) — `add_run_to_plan_entry/{plan_id}/{entry_id}`, `update_run_in_plan_entry/{run_id}`, `delete_run_from_plan_entry/{run_id}`; example payload `{"config_ids": [1, 5], "include_all": false, "case_ids": [1, 2, 4]}`; partial updates supported on update.
- [TestRail 6.4 release notes](https://support.testrail.com/hc/en-us/articles/17126024341268-TestRail-6-4-Default) — all three endpoints introduced in 6.4 (previously runs inside config-based entries could not be modified via API).
- [Runs – TestRail Support Center](https://support.testrail.com/hc/en-us/articles/7077874763156-Runs) — `update_run` accepts the same POST fields as `add_run` minus `suite_id`; `refs` requires TestRail 6.1+; `get_runs` supports the `milestone_id` filter.
- Cross-checked against the community OpenAPI spec in this repo (`openapi/testrail.yaml` on the #104 branch): `RunInput` includes `refs`; `get_runs`/`get_plans` document `milestone_id` + pagination envelope responses.

## Test plan

- Standard battery for every new/changed method: minimal params, all params, None values, error trio (`TestRailAPIError` / `TestRailAuthenticationError` / `TestRailRateLimitError`), asserting both call args and return values.
- Regression test `test_add_plan_entry_include_all_true_sent` asserts the payload contains `"include_all": True` (replaces the old `test_add_plan_entry_include_all_true_not_sent` which asserted the buggy behavior).
- `test_update_run_change_case_selection` covers the headline #141 workflow (`include_all=False` + `case_ids`).
- Envelope-shaped mock returns for `get_runs`/`get_plans` tests.

Results:

- `uv run pytest -q` — **444 passed**
- `uv run mypy src/` — **Success: no issues found in 26 source files**
- `uv run ruff format` (touched files) + `uv run ruff check src/ tests/` — **All checks passed**

Note: the pre-commit mypy hook fails on `runs.py`/`plans.py` at `origin/development` already (15 pre-existing errors — the hook checks `.py` bodies against `base.pyi`, where `_get`/`_post`/`_api_request` return `dict | list` unions while methods narrow to `dict`). That belongs to the #134 base-transport work; the documented gate `uv run mypy src/` passes.

Closes #141
Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)
