### PR TITLE
chore: remove orphaned __main__.pyi and sync stub __all__ lists

### DIFF
--- a/src/testrail_api_module/__main__.pyi
+++ b/src/testrail_api_module/__main__.pyi
@@ -1,1 +1,0 @@
-from .cli import main as main

--- a/src/testrail_api_module/attachments.pyi
+++ b/src/testrail_api_module/attachments.pyi
@@ -2,6 +2,8 @@ from typing import Any
 
 from .base import BaseAPI as BaseAPI
 
+__all__ = ["AttachmentsAPI"]
+
 class AttachmentsAPI(BaseAPI):
     def add_attachment_to_case(
         self, case_id: int, file_path: str

--- a/src/testrail_api_module/base.pyi
+++ b/src/testrail_api_module/base.pyi
@@ -4,6 +4,14 @@ from typing import Any, Literal, overload
 import requests
 from urllib3.util.retry import Retry
 
+__all__ = [
+    "BaseAPI",
+    "TestRailAPIError",
+    "TestRailAuthenticationError",
+    "TestRailRateLimitError",
+    "TestRailAPIException",
+]
+
 class TestRailAPIError(Exception):
     """Base exception class for TestRail API errors."""
 

--- a/src/testrail_api_module/bdd.pyi
+++ b/src/testrail_api_module/bdd.pyi
@@ -2,6 +2,8 @@ from typing import Any
 
 from .base import BaseAPI as BaseAPI
 
+__all__ = ["BDDAPI"]
+
 class BDDAPI(BaseAPI):
     """API for managing BDD scenarios in TestRail."""
     def get_bdd(self, case_id: int) -> bytes:

--- a/src/testrail_api_module/configurations.pyi
+++ b/src/testrail_api_module/configurations.pyi
@@ -1,6 +1,8 @@
 from typing import Any
 
-from .base import BaseAPI
+from .base import BaseAPI as BaseAPI
+
+__all__ = ["ConfigurationsAPI"]
 
 class ConfigurationsAPI(BaseAPI):
     def get_configs(self, project_id: int) -> list[dict[str, Any]]: ...

--- a/src/testrail_api_module/datasets.pyi
+++ b/src/testrail_api_module/datasets.pyi
@@ -2,6 +2,8 @@ from typing import Any
 
 from .base import BaseAPI as BaseAPI
 
+__all__ = ["DatasetsAPI"]
+
 class DatasetsAPI(BaseAPI):
     def get_dataset(self, dataset_id: int) -> dict[str, Any]: ...
     def get_datasets(self, project_id: int) -> list[dict[str, Any]]: ...

--- a/src/testrail_api_module/labels.pyi
+++ b/src/testrail_api_module/labels.pyi
@@ -1,6 +1,8 @@
 from typing import Any
 
-from .base import BaseAPI
+from .base import BaseAPI as BaseAPI
+
+__all__ = ["LabelsAPI"]
 
 class LabelsAPI(BaseAPI):
     def get_label(self, label_id: int) -> dict[str, Any]: ...

--- a/src/testrail_api_module/milestones.pyi
+++ b/src/testrail_api_module/milestones.pyi
@@ -2,6 +2,8 @@ from typing import Any
 
 from .base import BaseAPI as BaseAPI
 
+__all__ = ["MilestonesAPI"]
+
 class MilestonesAPI(BaseAPI):
     def get_milestone(self, milestone_id: int) -> dict[str, Any]: ...
     def get_milestones(self, project_id: int) -> list[dict[str, Any]]: ...

--- a/src/testrail_api_module/plans.pyi
+++ b/src/testrail_api_module/plans.pyi
@@ -2,6 +2,8 @@ from typing import Any
 
 from .base import BaseAPI as BaseAPI
 
+__all__ = ["PlansAPI"]
+
 class PlansAPI(BaseAPI):
     def get_plan(self, plan_id: int) -> dict[str, Any]: ...
     def get_plans(

--- a/src/testrail_api_module/priorities.pyi
+++ b/src/testrail_api_module/priorities.pyi
@@ -2,5 +2,7 @@ from typing import Any
 
 from .base import BaseAPI as BaseAPI
 
+__all__ = ["PrioritiesAPI"]
+
 class PrioritiesAPI(BaseAPI):
     def get_priorities(self) -> list[dict[str, Any]]: ...

--- a/src/testrail_api_module/projects.pyi
+++ b/src/testrail_api_module/projects.pyi
@@ -2,6 +2,8 @@ from typing import Any
 
 from .base import BaseAPI as BaseAPI
 
+__all__ = ["ProjectsAPI"]
+
 class ProjectsAPI(BaseAPI):
     def get_project(self, project_id: int) -> dict[str, Any]: ...
     def get_projects(self) -> list[dict[str, Any]]: ...

--- a/src/testrail_api_module/reports.pyi
+++ b/src/testrail_api_module/reports.pyi
@@ -2,6 +2,8 @@ from typing import Any
 
 from .base import BaseAPI as BaseAPI
 
+__all__ = ["ReportsAPI"]
+
 class ReportsAPI(BaseAPI):
     def get_reports(self, project_id: int) -> list[dict[str, Any]]: ...
     def run_report(self, report_id: int) -> dict[str, Any]: ...

--- a/src/testrail_api_module/result_fields.pyi
+++ b/src/testrail_api_module/result_fields.pyi
@@ -2,6 +2,8 @@ from typing import Any
 
 from .base import BaseAPI as BaseAPI
 
+__all__ = ["ResultFieldsAPI"]
+
 class ResultFieldsAPI(BaseAPI):
     """API for managing custom result fields in TestRail."""
     def get_result_fields(self) -> list[dict[str, Any]]:

--- a/src/testrail_api_module/roles.pyi
+++ b/src/testrail_api_module/roles.pyi
@@ -2,5 +2,7 @@ from typing import Any
 
 from .base import BaseAPI as BaseAPI
 
+__all__ = ["RolesAPI"]
+
 class RolesAPI(BaseAPI):
     def get_roles(self) -> list[dict[str, Any]]: ...

--- a/src/testrail_api_module/shared_steps.pyi
+++ b/src/testrail_api_module/shared_steps.pyi
@@ -2,6 +2,8 @@ from typing import Any
 
 from .base import BaseAPI as BaseAPI
 
+__all__ = ["SharedStepsAPI"]
+
 class SharedStepsAPI(BaseAPI):
     def get_shared_step(self, shared_step_id: int) -> dict[str, Any]: ...
     def get_shared_steps(self, project_id: int) -> list[dict[str, Any]]: ...

--- a/src/testrail_api_module/statuses.pyi
+++ b/src/testrail_api_module/statuses.pyi
@@ -2,6 +2,8 @@ from typing import Any
 
 from .base import BaseAPI as BaseAPI
 
+__all__ = ["StatusesAPI"]
+
 class StatusesAPI(BaseAPI):
     def get_statuses(self) -> list[dict[str, Any]]: ...
     def get_case_statuses(self) -> list[dict[str, Any]]: ...

--- a/src/testrail_api_module/suites.pyi
+++ b/src/testrail_api_module/suites.pyi
@@ -2,6 +2,8 @@ from typing import Any
 
 from .base import BaseAPI as BaseAPI
 
+__all__ = ["SuitesAPI"]
+
 class SuitesAPI(BaseAPI):
     def get_suite(self, suite_id: int) -> dict[str, Any]: ...
     def get_suites(self, project_id: int) -> list[dict[str, Any]]: ...

--- a/src/testrail_api_module/templates.pyi
+++ b/src/testrail_api_module/templates.pyi
@@ -2,5 +2,7 @@ from typing import Any
 
 from .base import BaseAPI as BaseAPI
 
+__all__ = ["TemplatesAPI"]
+
 class TemplatesAPI(BaseAPI):
     def get_templates(self, project_id: int) -> list[dict[str, Any]]: ...

--- a/src/testrail_api_module/tests.pyi
+++ b/src/testrail_api_module/tests.pyi
@@ -2,6 +2,8 @@ from typing import Any
 
 from .base import BaseAPI as BaseAPI
 
+__all__ = ["TestsAPI"]
+
 class TestsAPI(BaseAPI):
     def get_test(
         self, test_id: int, with_data: int | None = None

--- a/src/testrail_api_module/users.pyi
+++ b/src/testrail_api_module/users.pyi
@@ -2,6 +2,8 @@ from typing import Any
 
 from .base import BaseAPI as BaseAPI
 
+__all__ = ["UsersAPI"]
+
 class UsersAPI(BaseAPI):
     def get_user(self, user_id: int) -> dict[str, Any]: ...
     def get_users(

--- a/src/testrail_api_module/variables.pyi
+++ b/src/testrail_api_module/variables.pyi
@@ -2,6 +2,8 @@ from typing import Any
 
 from .base import BaseAPI as BaseAPI
 
+__all__ = ["VariablesAPI"]
+
 class VariablesAPI(BaseAPI):
     def get_variables(self, project_id: int) -> list[dict[str, Any]]: ...
     def add_variable(


### PR DESCRIPTION
## Summary

- Deletes `src/testrail_api_module/__main__.pyi` — the orphaned stub had no corresponding `__main__.py` to shadow
- Adds `__all__` to `base.pyi` (matching the 5-entry list in `base.py`)
- Adds `__all__` to all 19 single-class submodule stubs (`attachments` through `variables`) so every `.pyi` exports exactly what its `.py` counterpart does
- Fixes `configurations.pyi` and `labels.pyi` to use `BaseAPI as BaseAPI` (consistent re-export form), matching all other stubs

All 26 stub files now pass `mypy` without errors and `ruff` reports no issues.

## Test plan

- [x] `uv run mypy src/testrail_api_module/*.pyi` — Success: no issues found in 26 source files
- [x] `uv run ruff check . --fix && uv run ruff format .` — All checks passed, 85 files unchanged

Closes #155