### PR TITLE
fix: results, tests, statuses, and datasets API parity

### DIFF
--- a/src/testrail_api_module/datasets.py
+++ b/src/testrail_api_module/datasets.py
@@ -35,8 +35,11 @@ class DatasetsAPI(BaseAPI):
 
         Raises:
             TestRailAPIError: If the API request fails.
+
+        Example:
+            >>> dataset = api.datasets.get_dataset(dataset_id=1)
         """
-        return self._api_request("GET", f"get_dataset/{dataset_id}")
+        return self._get(f"get_dataset/{dataset_id}")
 
     def get_datasets(self, project_id: int) -> list[dict[str, Any]]:
         """
@@ -50,8 +53,11 @@ class DatasetsAPI(BaseAPI):
 
         Raises:
             TestRailAPIError: If the API request fails.
+
+        Example:
+            >>> datasets = api.datasets.get_datasets(project_id=1)
         """
-        return self._api_request("GET", f"get_datasets/{project_id}")
+        return self._get(f"get_datasets/{project_id}")
 
     def add_dataset(
         self,
@@ -73,31 +79,51 @@ class DatasetsAPI(BaseAPI):
 
         Raises:
             TestRailAPIError: If the API request fails.
+
+        Example:
+            >>> dataset = api.datasets.add_dataset(
+            ...     project_id=1,
+            ...     name="My Dataset",
+            ...     variables=[{"id": 1, "value": "test"}]
+            ... )
         """
         data: dict[str, Any] = {"name": name}
         if variables is not None:
             data["variables"] = variables
-        return self._api_request(
-            "POST", f"add_dataset/{project_id}", data=data
-        )
+        return self._post(f"add_dataset/{project_id}", data=data)
 
-    def update_dataset(self, dataset_id: int, **kwargs: Any) -> dict[str, Any]:
+    def update_dataset(
+        self,
+        dataset_id: int,
+        name: str | None = None,
+        variables: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
         """
         Update a dataset.
 
         Args:
             dataset_id: The ID of the dataset to update.
-            **kwargs: Fields to update (name, variables).
+            name: Optional new name for the dataset.
+            variables: Optional list of variable dicts to update.
 
         Returns:
             Dict containing the updated dataset data.
 
         Raises:
             TestRailAPIError: If the API request fails.
+
+        Example:
+            >>> dataset = api.datasets.update_dataset(
+            ...     dataset_id=1,
+            ...     name="Updated Dataset"
+            ... )
         """
-        return self._api_request(
-            "POST", f"update_dataset/{dataset_id}", data=kwargs
-        )
+        data: dict[str, Any] = {}
+        if name is not None:
+            data["name"] = name
+        if variables is not None:
+            data["variables"] = variables
+        return self._post(f"update_dataset/{dataset_id}", data=data)
 
     def delete_dataset(self, dataset_id: int) -> dict[str, Any]:
         """
@@ -107,9 +133,12 @@ class DatasetsAPI(BaseAPI):
             dataset_id: The ID of the dataset to delete.
 
         Returns:
-            Dict containing the response data.
+            Empty dict (TestRail returns an empty body on success).
 
         Raises:
             TestRailAPIError: If the API request fails.
+
+        Example:
+            >>> api.datasets.delete_dataset(dataset_id=1)
         """
-        return self._api_request("POST", f"delete_dataset/{dataset_id}")
+        return self._post(f"delete_dataset/{dataset_id}")

--- a/src/testrail_api_module/datasets.pyi
+++ b/src/testrail_api_module/datasets.pyi
@@ -12,6 +12,9 @@ class DatasetsAPI(BaseAPI):
         variables: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]: ...
     def update_dataset(
-        self, dataset_id: int, **kwargs: Any
+        self,
+        dataset_id: int,
+        name: str | None = None,
+        variables: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]: ...
     def delete_dataset(self, dataset_id: int) -> dict[str, Any]: ...

--- a/src/testrail_api_module/results.py
+++ b/src/testrail_api_module/results.py
@@ -21,18 +21,21 @@ class ResultsAPI(BaseAPI):
     def get_results(
         self,
         test_id: int,
-        status_id: int | list[int] | None = None,
+        defects_filter: str | None = None,
         limit: int | None = None,
         offset: int | None = None,
+        status_id: int | list[int] | None = None,
     ) -> list[dict[str, Any]]:
         """
         Get all results for a specific test.
 
         Args:
             test_id: The ID of the test.
-            status_id: Optional status ID(s) to filter by.
+            defects_filter: Optional defect ID to filter by
+                (e.g., 'TR-1', '4291').
             limit: Optional limit on number of results.
             offset: Optional offset for pagination.
+            status_id: Optional status ID(s) to filter by.
 
         Returns:
             List of dictionaries containing test result data.
@@ -44,23 +47,25 @@ class ResultsAPI(BaseAPI):
             >>> results = api.results.get_results(test_id=42)
         """
         params: dict[str, Any] = {}
+        if defects_filter is not None:
+            params["defects_filter"] = defects_filter
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
         if status_id is not None:
             params["status_id"] = (
                 ",".join(map(str, status_id))
                 if isinstance(status_id, list)
                 else status_id
             )
-        if limit is not None:
-            params["limit"] = limit
-        if offset is not None:
-            params["offset"] = offset
 
         return self._get(f"get_results/{test_id}", params=params)
 
     def add_result(
         self,
         test_id: int,
-        status_id: int,
+        status_id: int | None = None,
         comment: str | None = None,
         version: str | None = None,
         elapsed: str | None = None,
@@ -73,7 +78,7 @@ class ResultsAPI(BaseAPI):
 
         Args:
             test_id: The ID of the test.
-            status_id: The status ID (1: Passed, 2: Blocked,
+            status_id: Optional status ID (1: Passed, 2: Blocked,
                 3: Untested, 4: Retest, 5: Failed).
             comment: Optional comment for the test result.
             version: Optional version of the software under test.
@@ -95,9 +100,10 @@ class ResultsAPI(BaseAPI):
             ...     comment="Test passed successfully"
             ... )
         """
-        data: dict[str, Any] = {"status_id": status_id}
+        data: dict[str, Any] = {}
 
         optional_fields = {
+            "status_id": status_id,
             "comment": comment,
             "version": version,
             "elapsed": elapsed,
@@ -118,7 +124,7 @@ class ResultsAPI(BaseAPI):
         self,
         run_id: int,
         case_id: int,
-        status_id: int,
+        status_id: int | None = None,
         comment: str | None = None,
         version: str | None = None,
         elapsed: str | None = None,
@@ -132,7 +138,7 @@ class ResultsAPI(BaseAPI):
         Args:
             run_id: The ID of the test run.
             case_id: The ID of the test case.
-            status_id: The status ID (1: Passed, 2: Blocked,
+            status_id: Optional status ID (1: Passed, 2: Blocked,
                 3: Untested, 4: Retest, 5: Failed).
             comment: Optional comment for the test result.
             version: Optional version of the software under test.
@@ -156,9 +162,10 @@ class ResultsAPI(BaseAPI):
             ...     elapsed="30s"
             ... )
         """
-        data: dict[str, Any] = {"status_id": status_id}
+        data: dict[str, Any] = {}
 
         optional_fields = {
+            "status_id": status_id,
             "comment": comment,
             "version": version,
             "elapsed": elapsed,
@@ -212,7 +219,13 @@ class ResultsAPI(BaseAPI):
         )
 
     def get_results_for_case(
-        self, run_id: int, case_id: int
+        self,
+        run_id: int,
+        case_id: int,
+        defects_filter: str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        status_id: int | list[int] | None = None,
     ) -> list[dict[str, Any]]:
         """
         Get all test results for a specific test case in a test run.
@@ -220,6 +233,11 @@ class ResultsAPI(BaseAPI):
         Args:
             run_id: The ID of the test run.
             case_id: The ID of the test case.
+            defects_filter: Optional defect ID to filter by
+                (e.g., 'TR-1', '4291').
+            limit: Optional limit on number of results to return.
+            offset: Optional offset for pagination.
+            status_id: Optional status ID(s) to filter by.
 
         Returns:
             List of dictionaries containing test result data.
@@ -228,11 +246,26 @@ class ResultsAPI(BaseAPI):
             TestRailAPIError: If the API request fails.
 
         Example:
-            >>> results = api.results.get_results_for_case(run_id=1, case_id=123)
-            >>> for result in results:
-            ...     print(f"Result: {result['status_id']} - {result['comment']}")
+            >>> results = api.results.get_results_for_case(
+            ...     run_id=1, case_id=123
+            ... )
         """
-        return self._get(f"get_results_for_case/{run_id}/{case_id}")
+        params: dict[str, Any] = {}
+        if defects_filter is not None:
+            params["defects_filter"] = defects_filter
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+        if status_id is not None:
+            params["status_id"] = (
+                ",".join(map(str, status_id))
+                if isinstance(status_id, list)
+                else status_id
+            )
+        return self._get(
+            f"get_results_for_case/{run_id}/{case_id}", params=params
+        )
 
     def get_results_for_run(
         self,

--- a/src/testrail_api_module/results.pyi
+++ b/src/testrail_api_module/results.pyi
@@ -9,15 +9,16 @@ class ResultsAPI(BaseAPI):
     def get_results(
         self,
         test_id: int,
-        status_id: int | list[int] | None = ...,
+        defects_filter: str | None = ...,
         limit: int | None = ...,
         offset: int | None = ...,
+        status_id: int | list[int] | None = ...,
     ) -> list[dict[str, Any]]:
         """Get all results for a specific test."""
     def add_result(
         self,
         test_id: int,
-        status_id: int,
+        status_id: int | None = ...,
         comment: str | None = ...,
         version: str | None = ...,
         elapsed: str | None = ...,
@@ -30,7 +31,7 @@ class ResultsAPI(BaseAPI):
         self,
         run_id: int,
         case_id: int,
-        status_id: int,
+        status_id: int | None = ...,
         comment: str | None = ...,
         version: str | None = ...,
         elapsed: str | None = ...,
@@ -44,19 +45,25 @@ class ResultsAPI(BaseAPI):
     ) -> list[dict[str, Any]]:
         """Add multiple test results for test cases in a test run."""
     def get_results_for_case(
-        self, run_id: int, case_id: int
+        self,
+        run_id: int,
+        case_id: int,
+        defects_filter: str | None = ...,
+        limit: int | None = ...,
+        offset: int | None = ...,
+        status_id: int | list[int] | None = ...,
     ) -> list[dict[str, Any]]:
         """Get all test results for a specific test case in a test run."""
     def get_results_for_run(
         self,
         run_id: int,
-        status_id: int | list[int] | None = ...,
         created_after: int | None = ...,
         created_before: int | None = ...,
         created_by: int | list[int] | None = ...,
         defects_filter: str | None = ...,
         limit: int | None = ...,
         offset: int | None = ...,
+        status_id: int | list[int] | None = ...,
     ) -> list[dict[str, Any]]:
         """Get all test results for a test run."""
     def add_results(

--- a/src/testrail_api_module/statuses.py
+++ b/src/testrail_api_module/statuses.py
@@ -27,8 +27,11 @@ class StatusesAPI(BaseAPI):
 
         Raises:
             TestRailAPIError: If the API request fails.
+
+        Example:
+            >>> statuses = api.statuses.get_statuses()
         """
-        return self._api_request("GET", "get_statuses")
+        return self._get("get_statuses")
 
     def get_case_statuses(self) -> list[dict[str, Any]]:
         """
@@ -41,5 +44,8 @@ class StatusesAPI(BaseAPI):
 
         Raises:
             TestRailAPIError: If the API request fails.
+
+        Example:
+            >>> case_statuses = api.statuses.get_case_statuses()
         """
-        return self._api_request("GET", "get_case_statuses")
+        return self._get("get_case_statuses")

--- a/src/testrail_api_module/tests.py
+++ b/src/testrail_api_module/tests.py
@@ -49,21 +49,26 @@ class TestsAPI(BaseAPI):
     def get_tests(
         self,
         run_id: int,
-        status_id: int | list[int] | None = None,
+        assignedto_id: int | list[int] | None = None,
+        case_id: int | list[int] | None = None,
         limit: int | None = None,
         offset: int | None = None,
-        label_id: int | list[int] | None = None,
+        status_id: int | list[int] | None = None,
+        with_data: int | None = None,
     ) -> list[dict[str, Any]]:
         """
         Get all tests for a test run.
 
         Args:
             run_id: The ID of the test run to get tests for.
-            status_id: Optional status ID(s) to filter by.
+            assignedto_id: Optional user ID(s) to filter by assignee.
+            case_id: Optional case ID(s) to filter by.
             limit: Optional limit on number of results
                 (default 250).
             offset: Optional offset for pagination.
-            label_id: Optional label ID(s) to filter by.
+            status_id: Optional status ID(s) to filter by.
+            with_data: Optional parameter to include additional
+                data in the response.
 
         Returns:
             List of dictionaries containing test data.
@@ -79,22 +84,30 @@ class TestsAPI(BaseAPI):
             ...     limit=100
             ... )
         """
-        params = {}
+        params: dict[str, Any] = {}
+        if assignedto_id is not None:
+            params["assignedto_id"] = (
+                ",".join(map(str, assignedto_id))
+                if isinstance(assignedto_id, list)
+                else assignedto_id
+            )
+        if case_id is not None:
+            params["case_id"] = (
+                ",".join(map(str, case_id))
+                if isinstance(case_id, list)
+                else case_id
+            )
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
         if status_id is not None:
             params["status_id"] = (
                 ",".join(map(str, status_id))
                 if isinstance(status_id, list)
                 else status_id
             )
-        if limit is not None:
-            params["limit"] = limit
-        if offset is not None:
-            params["offset"] = offset
-        if label_id is not None:
-            params["label_id"] = (
-                ",".join(map(str, label_id))
-                if isinstance(label_id, list)
-                else label_id
-            )
+        if with_data is not None:
+            params["with_data"] = with_data
 
         return self._get(f"get_tests/{run_id}", params=params)

--- a/src/testrail_api_module/tests.pyi
+++ b/src/testrail_api_module/tests.pyi
@@ -9,8 +9,10 @@ class TestsAPI(BaseAPI):
     def get_tests(
         self,
         run_id: int,
-        status_id: int | list[int] | None = None,
+        assignedto_id: int | list[int] | None = None,
+        case_id: int | list[int] | None = None,
         limit: int | None = None,
         offset: int | None = None,
-        label_id: int | list[int] | None = None,
+        status_id: int | list[int] | None = None,
+        with_data: int | None = None,
     ) -> list[dict[str, Any]]: ...

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -39,79 +39,52 @@ class TestDatasetsAPI:
         """Create a DatasetsAPI instance with mocked client."""
         return DatasetsAPI(mock_client)
 
+    @pytest.fixture
+    def sample_dataset_data(self) -> dict:
+        """Sample dataset data for testing."""
+        return {
+            "id": 1,
+            "name": "Test Dataset",
+            "variables": [
+                {"id": 1, "name": "username", "value": "testuser"},
+                {"id": 2, "name": "password", "value": "testpass"},
+            ],
+        }
+
+    # -------------------------------------------------------------------------
+    # Initialization
+    # -------------------------------------------------------------------------
+
     def test_init(self, mock_client: Mock) -> None:
         """Test DatasetsAPI initialization."""
         api = DatasetsAPI(mock_client)
         assert api.client == mock_client
         assert hasattr(api, "logger")
 
-    def test_get_dataset(self, datasets_api: DatasetsAPI) -> None:
-        """Test get_dataset method."""
-        with patch.object(datasets_api, "_api_request") as mock_request:
-            mock_request.return_value = {
-                "id": 1,
-                "name": "Test Dataset",
-                "variables": [
-                    {"id": 1, "name": "var1", "value": "value1"},
-                    {"id": 2, "name": "var2", "value": "value2"},
-                ],
-            }
+    # -------------------------------------------------------------------------
+    # get_dataset
+    # -------------------------------------------------------------------------
+
+    def test_get_dataset_minimal(
+        self,
+        datasets_api: DatasetsAPI,
+        sample_dataset_data: dict,
+    ) -> None:
+        """Test get_dataset with minimal required parameters."""
+        with patch.object(datasets_api, "_get") as mock_get:
+            mock_get.return_value = sample_dataset_data
 
             result = datasets_api.get_dataset(dataset_id=1)
 
-            mock_request.assert_called_once_with("GET", "get_dataset/1")
-            assert result is not None
-            assert result["id"] == 1
-            assert result["name"] == "Test Dataset"
-            assert len(result["variables"]) == 2
-            assert result["variables"][0]["name"] == "var1"
-
-    def test_get_datasets(self, datasets_api: DatasetsAPI) -> None:
-        """Test get_datasets method."""
-        with patch.object(datasets_api, "_api_request") as mock_request:
-            mock_request.return_value = [
-                {
-                    "id": 1,
-                    "name": "Dataset 1",
-                    "variables": [
-                        {"id": 1, "name": "var1", "value": "value1"}
-                    ],
-                },
-                {
-                    "id": 2,
-                    "name": "Dataset 2",
-                    "variables": [
-                        {"id": 2, "name": "var2", "value": "value2"}
-                    ],
-                },
-            ]
-
-            result = datasets_api.get_datasets(project_id=1)
-
-            mock_request.assert_called_once_with("GET", "get_datasets/1")
-            assert result is not None
-            assert len(result) == 2
-            assert result[0]["id"] == 1
-            assert result[0]["name"] == "Dataset 1"
-            assert result[1]["id"] == 2
-            assert result[1]["name"] == "Dataset 2"
-
-    def test_get_datasets_empty_list(self, datasets_api: DatasetsAPI) -> None:
-        """Test get_datasets with empty result."""
-        with patch.object(datasets_api, "_api_request") as mock_request:
-            mock_request.return_value = []
-
-            result = datasets_api.get_datasets(project_id=1)
-
-            mock_request.assert_called_once_with("GET", "get_datasets/1")
-            assert result == []
+            mock_get.assert_called_once_with("get_dataset/1")
+            assert result == sample_dataset_data
 
     def test_get_dataset_with_variables(
         self, datasets_api: DatasetsAPI
     ) -> None:
-        """Test get_dataset with multiple variables."""
-        with patch.object(datasets_api, "_api_request") as mock_request:
-            mock_request.return_value = {
+        """Test get_dataset returns dataset with variables array."""
+        with patch.object(datasets_api, "_get") as mock_get:
+            mock_get.return_value = {
                 "id": 5,
                 "name": "Complex Dataset",
                 "variables": [
@@ -123,57 +96,38 @@ class TestDatasetsAPI:
 
             result = datasets_api.get_dataset(dataset_id=5)
 
-            mock_request.assert_called_once_with("GET", "get_dataset/5")
-            assert result is not None
+            mock_get.assert_called_once_with("get_dataset/5")
             assert len(result["variables"]) == 3
             assert result["variables"][0]["name"] == "username"
-            assert result["variables"][1]["name"] == "password"
-            assert result["variables"][2]["name"] == "environment"
-
-    def test_get_datasets_different_project_ids(
-        self, datasets_api: DatasetsAPI
-    ) -> None:
-        """Test get_datasets with different project IDs."""
-        with patch.object(datasets_api, "_api_request") as mock_request:
-            mock_request.return_value = [{"id": 1, "name": "Dataset 1"}]
-
-            result1 = datasets_api.get_datasets(project_id=1)
-            result2 = datasets_api.get_datasets(project_id=2)
-
-            assert mock_request.call_count == 2
-            mock_request.assert_any_call("GET", "get_datasets/1")
-            mock_request.assert_any_call("GET", "get_datasets/2")
-            assert result1 is not None
-            assert result2 is not None
 
     def test_get_dataset_different_ids(
         self, datasets_api: DatasetsAPI
     ) -> None:
         """Test get_dataset with different dataset IDs."""
-        with patch.object(datasets_api, "_api_request") as mock_request:
-            mock_request.return_value = {"id": 1, "name": "Dataset"}
+        with patch.object(datasets_api, "_get") as mock_get:
+            mock_get.return_value = {"id": 1, "name": "Dataset"}
 
-            result1 = datasets_api.get_dataset(dataset_id=1)
-            result2 = datasets_api.get_dataset(dataset_id=100)
+            datasets_api.get_dataset(dataset_id=1)
+            datasets_api.get_dataset(dataset_id=100)
 
-            assert mock_request.call_count == 2
-            mock_request.assert_any_call("GET", "get_dataset/1")
-            mock_request.assert_any_call("GET", "get_dataset/100")
-            assert result1 is not None
-            assert result2 is not None
+            assert mock_get.call_count == 2
+            mock_get.assert_any_call("get_dataset/1")
+            mock_get.assert_any_call("get_dataset/100")
 
-    def test_api_request_failure(self, datasets_api: DatasetsAPI) -> None:
-        """Test behavior when API request fails."""
-        with patch.object(datasets_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAPIError("API request failed")
+    def test_get_dataset_api_error(self, datasets_api: DatasetsAPI) -> None:
+        """Test get_dataset raises TestRailAPIError on API failure."""
+        with patch.object(datasets_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAPIError("API request failed")
 
             with pytest.raises(TestRailAPIError, match="API request failed"):
                 datasets_api.get_dataset(dataset_id=1)
 
-    def test_authentication_error(self, datasets_api: DatasetsAPI) -> None:
-        """Test behavior when authentication fails."""
-        with patch.object(datasets_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAuthenticationError(
+    def test_get_dataset_authentication_error(
+        self, datasets_api: DatasetsAPI
+    ) -> None:
+        """Test get_dataset raises TestRailAuthenticationError."""
+        with patch.object(datasets_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAuthenticationError(
                 "Authentication failed"
             )
 
@@ -182,10 +136,12 @@ class TestDatasetsAPI:
             ):
                 datasets_api.get_dataset(dataset_id=1)
 
-    def test_rate_limit_error(self, datasets_api: DatasetsAPI) -> None:
-        """Test behavior when rate limit is exceeded."""
-        with patch.object(datasets_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailRateLimitError(
+    def test_get_dataset_rate_limit_error(
+        self, datasets_api: DatasetsAPI
+    ) -> None:
+        """Test get_dataset raises TestRailRateLimitError."""
+        with patch.object(datasets_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailRateLimitError(
                 "Rate limit exceeded"
             )
 
@@ -194,12 +150,53 @@ class TestDatasetsAPI:
             ):
                 datasets_api.get_dataset(dataset_id=1)
 
-    def test_get_datasets_api_request_failure(
+    # -------------------------------------------------------------------------
+    # get_datasets
+    # -------------------------------------------------------------------------
+
+    def test_get_datasets_minimal(self, datasets_api: DatasetsAPI) -> None:
+        """Test get_datasets with minimal required parameters."""
+        with patch.object(datasets_api, "_get") as mock_get:
+            mock_get.return_value = [
+                {"id": 1, "name": "Dataset 1"},
+                {"id": 2, "name": "Dataset 2"},
+            ]
+
+            result = datasets_api.get_datasets(project_id=1)
+
+            mock_get.assert_called_once_with("get_datasets/1")
+            assert len(result) == 2
+            assert result[0]["id"] == 1
+            assert result[1]["id"] == 2
+
+    def test_get_datasets_empty_list(self, datasets_api: DatasetsAPI) -> None:
+        """Test get_datasets returns empty list when no datasets exist."""
+        with patch.object(datasets_api, "_get") as mock_get:
+            mock_get.return_value = []
+
+            result = datasets_api.get_datasets(project_id=1)
+
+            mock_get.assert_called_once_with("get_datasets/1")
+            assert result == []
+
+    def test_get_datasets_different_project_ids(
         self, datasets_api: DatasetsAPI
     ) -> None:
-        """Test get_datasets behavior when API request fails."""
-        with patch.object(datasets_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAPIError("API request failed")
+        """Test get_datasets with different project IDs."""
+        with patch.object(datasets_api, "_get") as mock_get:
+            mock_get.return_value = [{"id": 1, "name": "Dataset 1"}]
+
+            datasets_api.get_datasets(project_id=1)
+            datasets_api.get_datasets(project_id=2)
+
+            assert mock_get.call_count == 2
+            mock_get.assert_any_call("get_datasets/1")
+            mock_get.assert_any_call("get_datasets/2")
+
+    def test_get_datasets_api_error(self, datasets_api: DatasetsAPI) -> None:
+        """Test get_datasets raises TestRailAPIError on API failure."""
+        with patch.object(datasets_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAPIError("API request failed")
 
             with pytest.raises(TestRailAPIError, match="API request failed"):
                 datasets_api.get_datasets(project_id=1)
@@ -207,9 +204,9 @@ class TestDatasetsAPI:
     def test_get_datasets_authentication_error(
         self, datasets_api: DatasetsAPI
     ) -> None:
-        """Test get_datasets behavior when authentication fails."""
-        with patch.object(datasets_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAuthenticationError(
+        """Test get_datasets raises TestRailAuthenticationError."""
+        with patch.object(datasets_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAuthenticationError(
                 "Authentication failed"
             )
 
@@ -221,9 +218,9 @@ class TestDatasetsAPI:
     def test_get_datasets_rate_limit_error(
         self, datasets_api: DatasetsAPI
     ) -> None:
-        """Test get_datasets behavior when rate limit is exceeded."""
-        with patch.object(datasets_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailRateLimitError(
+        """Test get_datasets raises TestRailRateLimitError."""
+        with patch.object(datasets_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailRateLimitError(
                 "Rate limit exceeded"
             )
 
@@ -231,3 +228,292 @@ class TestDatasetsAPI:
                 TestRailRateLimitError, match="Rate limit exceeded"
             ):
                 datasets_api.get_datasets(project_id=1)
+
+    # -------------------------------------------------------------------------
+    # add_dataset
+    # -------------------------------------------------------------------------
+
+    def test_add_dataset_minimal(self, datasets_api: DatasetsAPI) -> None:
+        """Test add_dataset with only required parameters."""
+        with patch.object(datasets_api, "_post") as mock_post:
+            mock_post.return_value = {"id": 1, "name": "My Dataset"}
+
+            result = datasets_api.add_dataset(project_id=1, name="My Dataset")
+
+            expected_data = {"name": "My Dataset"}
+            mock_post.assert_called_once_with(
+                "add_dataset/1", data=expected_data
+            )
+            assert result == {"id": 1, "name": "My Dataset"}
+
+    def test_add_dataset_with_variables(
+        self, datasets_api: DatasetsAPI
+    ) -> None:
+        """Test add_dataset with variables list."""
+        with patch.object(datasets_api, "_post") as mock_post:
+            variables = [
+                {"id": 1, "value": "user1"},
+                {"id": 2, "value": "pass1"},
+            ]
+            mock_post.return_value = {
+                "id": 1,
+                "name": "My Dataset",
+                "variables": variables,
+            }
+
+            result = datasets_api.add_dataset(
+                project_id=1,
+                name="My Dataset",
+                variables=variables,
+            )
+
+            expected_data = {"name": "My Dataset", "variables": variables}
+            mock_post.assert_called_once_with(
+                "add_dataset/1", data=expected_data
+            )
+            assert result["variables"] == variables
+
+    def test_add_dataset_with_none_variables(
+        self, datasets_api: DatasetsAPI
+    ) -> None:
+        """Test add_dataset with variables=None omits variables from payload."""
+        with patch.object(datasets_api, "_post") as mock_post:
+            mock_post.return_value = {"id": 1, "name": "My Dataset"}
+
+            datasets_api.add_dataset(
+                project_id=1, name="My Dataset", variables=None
+            )
+
+            expected_data = {"name": "My Dataset"}
+            mock_post.assert_called_once_with(
+                "add_dataset/1", data=expected_data
+            )
+
+    def test_add_dataset_api_error(self, datasets_api: DatasetsAPI) -> None:
+        """Test add_dataset raises TestRailAPIError on API failure."""
+        with patch.object(datasets_api, "_post") as mock_post:
+            mock_post.side_effect = TestRailAPIError("API request failed")
+
+            with pytest.raises(TestRailAPIError, match="API request failed"):
+                datasets_api.add_dataset(project_id=1, name="My Dataset")
+
+    def test_add_dataset_authentication_error(
+        self, datasets_api: DatasetsAPI
+    ) -> None:
+        """Test add_dataset raises TestRailAuthenticationError."""
+        with patch.object(datasets_api, "_post") as mock_post:
+            mock_post.side_effect = TestRailAuthenticationError(
+                "Authentication failed"
+            )
+
+            with pytest.raises(
+                TestRailAuthenticationError, match="Authentication failed"
+            ):
+                datasets_api.add_dataset(project_id=1, name="My Dataset")
+
+    def test_add_dataset_rate_limit_error(
+        self, datasets_api: DatasetsAPI
+    ) -> None:
+        """Test add_dataset raises TestRailRateLimitError."""
+        with patch.object(datasets_api, "_post") as mock_post:
+            mock_post.side_effect = TestRailRateLimitError(
+                "Rate limit exceeded"
+            )
+
+            with pytest.raises(
+                TestRailRateLimitError, match="Rate limit exceeded"
+            ):
+                datasets_api.add_dataset(project_id=1, name="My Dataset")
+
+    # -------------------------------------------------------------------------
+    # update_dataset
+    # -------------------------------------------------------------------------
+
+    def test_update_dataset_minimal(self, datasets_api: DatasetsAPI) -> None:
+        """Test update_dataset with no optional parameters sends empty body."""
+        with patch.object(datasets_api, "_post") as mock_post:
+            mock_post.return_value = {"id": 1, "name": "Original"}
+
+            result = datasets_api.update_dataset(dataset_id=1)
+
+            mock_post.assert_called_once_with("update_dataset/1", data={})
+            assert result == {"id": 1, "name": "Original"}
+
+    def test_update_dataset_with_name(self, datasets_api: DatasetsAPI) -> None:
+        """Test update_dataset with name parameter."""
+        with patch.object(datasets_api, "_post") as mock_post:
+            mock_post.return_value = {"id": 1, "name": "Updated Dataset"}
+
+            result = datasets_api.update_dataset(
+                dataset_id=1, name="Updated Dataset"
+            )
+
+            expected_data = {"name": "Updated Dataset"}
+            mock_post.assert_called_once_with(
+                "update_dataset/1", data=expected_data
+            )
+            assert result["name"] == "Updated Dataset"
+
+    def test_update_dataset_with_variables(
+        self, datasets_api: DatasetsAPI
+    ) -> None:
+        """Test update_dataset with variables parameter."""
+        with patch.object(datasets_api, "_post") as mock_post:
+            variables = [{"id": 1, "value": "new_value"}]
+            mock_post.return_value = {"id": 1, "variables": variables}
+
+            result = datasets_api.update_dataset(
+                dataset_id=1, variables=variables
+            )
+
+            expected_data = {"variables": variables}
+            mock_post.assert_called_once_with(
+                "update_dataset/1", data=expected_data
+            )
+            assert result["variables"] == variables
+
+    def test_update_dataset_with_all_parameters(
+        self, datasets_api: DatasetsAPI
+    ) -> None:
+        """Test update_dataset with all optional parameters."""
+        with patch.object(datasets_api, "_post") as mock_post:
+            variables = [{"id": 1, "value": "value1"}]
+            mock_post.return_value = {
+                "id": 1,
+                "name": "New Name",
+                "variables": variables,
+            }
+
+            result = datasets_api.update_dataset(
+                dataset_id=1,
+                name="New Name",
+                variables=variables,
+            )
+
+            expected_data = {"name": "New Name", "variables": variables}
+            mock_post.assert_called_once_with(
+                "update_dataset/1", data=expected_data
+            )
+            assert result["name"] == "New Name"
+
+    def test_update_dataset_with_none_values(
+        self, datasets_api: DatasetsAPI
+    ) -> None:
+        """Test update_dataset with None values excludes them from payload."""
+        with patch.object(datasets_api, "_post") as mock_post:
+            mock_post.return_value = {"id": 1}
+
+            datasets_api.update_dataset(
+                dataset_id=1, name=None, variables=None
+            )
+
+            mock_post.assert_called_once_with("update_dataset/1", data={})
+
+    def test_update_dataset_api_error(self, datasets_api: DatasetsAPI) -> None:
+        """Test update_dataset raises TestRailAPIError on API failure."""
+        with patch.object(datasets_api, "_post") as mock_post:
+            mock_post.side_effect = TestRailAPIError("API request failed")
+
+            with pytest.raises(TestRailAPIError, match="API request failed"):
+                datasets_api.update_dataset(dataset_id=1, name="New Name")
+
+    def test_update_dataset_authentication_error(
+        self, datasets_api: DatasetsAPI
+    ) -> None:
+        """Test update_dataset raises TestRailAuthenticationError."""
+        with patch.object(datasets_api, "_post") as mock_post:
+            mock_post.side_effect = TestRailAuthenticationError(
+                "Authentication failed"
+            )
+
+            with pytest.raises(
+                TestRailAuthenticationError, match="Authentication failed"
+            ):
+                datasets_api.update_dataset(dataset_id=1, name="New Name")
+
+    def test_update_dataset_rate_limit_error(
+        self, datasets_api: DatasetsAPI
+    ) -> None:
+        """Test update_dataset raises TestRailRateLimitError."""
+        with patch.object(datasets_api, "_post") as mock_post:
+            mock_post.side_effect = TestRailRateLimitError(
+                "Rate limit exceeded"
+            )
+
+            with pytest.raises(
+                TestRailRateLimitError, match="Rate limit exceeded"
+            ):
+                datasets_api.update_dataset(dataset_id=1, name="New Name")
+
+    # -------------------------------------------------------------------------
+    # delete_dataset
+    # -------------------------------------------------------------------------
+
+    def test_delete_dataset_minimal(self, datasets_api: DatasetsAPI) -> None:
+        """Test delete_dataset with required parameters."""
+        with patch.object(datasets_api, "_post") as mock_post:
+            mock_post.return_value = {}
+
+            result = datasets_api.delete_dataset(dataset_id=1)
+
+            mock_post.assert_called_once_with("delete_dataset/1")
+            assert result == {}
+
+    def test_delete_dataset_different_ids(
+        self, datasets_api: DatasetsAPI
+    ) -> None:
+        """Test delete_dataset with different dataset IDs."""
+        with patch.object(datasets_api, "_post") as mock_post:
+            mock_post.return_value = {}
+
+            datasets_api.delete_dataset(dataset_id=1)
+            datasets_api.delete_dataset(dataset_id=99)
+
+            assert mock_post.call_count == 2
+            mock_post.assert_any_call("delete_dataset/1")
+            mock_post.assert_any_call("delete_dataset/99")
+
+    def test_delete_dataset_large_id(self, datasets_api: DatasetsAPI) -> None:
+        """Test delete_dataset with a large dataset_id value."""
+        with patch.object(datasets_api, "_post") as mock_post:
+            mock_post.return_value = {}
+
+            datasets_api.delete_dataset(dataset_id=999999)
+
+            mock_post.assert_called_once_with("delete_dataset/999999")
+
+    def test_delete_dataset_api_error(self, datasets_api: DatasetsAPI) -> None:
+        """Test delete_dataset raises TestRailAPIError on API failure."""
+        with patch.object(datasets_api, "_post") as mock_post:
+            mock_post.side_effect = TestRailAPIError("API request failed")
+
+            with pytest.raises(TestRailAPIError, match="API request failed"):
+                datasets_api.delete_dataset(dataset_id=1)
+
+    def test_delete_dataset_authentication_error(
+        self, datasets_api: DatasetsAPI
+    ) -> None:
+        """Test delete_dataset raises TestRailAuthenticationError."""
+        with patch.object(datasets_api, "_post") as mock_post:
+            mock_post.side_effect = TestRailAuthenticationError(
+                "Authentication failed"
+            )
+
+            with pytest.raises(
+                TestRailAuthenticationError, match="Authentication failed"
+            ):
+                datasets_api.delete_dataset(dataset_id=1)
+
+    def test_delete_dataset_rate_limit_error(
+        self, datasets_api: DatasetsAPI
+    ) -> None:
+        """Test delete_dataset raises TestRailRateLimitError."""
+        with patch.object(datasets_api, "_post") as mock_post:
+            mock_post.side_effect = TestRailRateLimitError(
+                "Rate limit exceeded"
+            )
+
+            with pytest.raises(
+                TestRailRateLimitError, match="Rate limit exceeded"
+            ):
+                datasets_api.delete_dataset(dataset_id=1)

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -90,15 +90,17 @@ class TestResultsAPI:
 
             result = results_api.get_results(
                 test_id=42,
-                status_id=[1, 5],
+                defects_filter="TR-1",
                 limit=50,
                 offset=10,
+                status_id=[1, 5],
             )
 
             expected_params = {
-                "status_id": "1,5",
+                "defects_filter": "TR-1",
                 "limit": 50,
                 "offset": 10,
+                "status_id": "1,5",
             }
             mock_get.assert_called_once_with(
                 "get_results/42", params=expected_params
@@ -114,13 +116,28 @@ class TestResultsAPI:
 
             result = results_api.get_results(
                 test_id=42,
-                status_id=None,
+                defects_filter=None,
                 limit=None,
                 offset=None,
+                status_id=None,
             )
 
             mock_get.assert_called_once_with("get_results/42", params={})
             assert result == [{"id": 1, "status_id": 1}]
+
+    def test_get_results_with_defects_filter(
+        self, results_api: ResultsAPI
+    ) -> None:
+        """Test get_results with defects_filter parameter."""
+        with patch.object(results_api, "_get") as mock_get:
+            mock_get.return_value = [{"id": 1, "status_id": 5}]
+
+            results_api.get_results(test_id=42, defects_filter="TR-42")
+
+            expected_params = {"defects_filter": "TR-42"}
+            mock_get.assert_called_once_with(
+                "get_results/42", params=expected_params
+            )
 
     def test_get_results_with_single_status_id(
         self, results_api: ResultsAPI
@@ -205,7 +222,17 @@ class TestResultsAPI:
     # -------------------------------------------------------------------------
 
     def test_add_result_minimal(self, results_api: ResultsAPI) -> None:
-        """Test add_result with minimal required parameters."""
+        """Test add_result with no parameters (status_id is optional)."""
+        with patch.object(results_api, "_post") as mock_post:
+            mock_post.return_value = {"id": 1}
+
+            result = results_api.add_result(test_id=101)
+
+            mock_post.assert_called_once_with("add_result/101", data={})
+            assert result == {"id": 1}
+
+    def test_add_result_with_status_id(self, results_api: ResultsAPI) -> None:
+        """Test add_result with status_id provided."""
         with patch.object(results_api, "_post") as mock_post:
             mock_post.return_value = {"id": 1, "status_id": 1}
 
@@ -252,13 +279,13 @@ class TestResultsAPI:
     def test_add_result_with_none_values(
         self, results_api: ResultsAPI
     ) -> None:
-        """Test add_result with None values for optional parameters."""
+        """Test add_result with None values for all optional parameters."""
         with patch.object(results_api, "_post") as mock_post:
-            mock_post.return_value = {"id": 1, "status_id": 1}
+            mock_post.return_value = {"id": 1}
 
             result = results_api.add_result(
                 test_id=101,
-                status_id=1,
+                status_id=None,
                 comment=None,
                 version=None,
                 elapsed=None,
@@ -267,11 +294,8 @@ class TestResultsAPI:
                 custom_fields=None,
             )
 
-            expected_data = {"status_id": 1}
-            mock_post.assert_called_once_with(
-                "add_result/101", data=expected_data
-            )
-            assert result == {"id": 1, "status_id": 1}
+            mock_post.assert_called_once_with("add_result/101", data={})
+            assert result == {"id": 1}
 
     def test_add_result_with_custom_fields(
         self, results_api: ResultsAPI
@@ -389,7 +413,21 @@ class TestResultsAPI:
     def test_add_result_for_case_minimal(
         self, results_api: ResultsAPI
     ) -> None:
-        """Test add_result_for_case with minimal required parameters."""
+        """Test add_result_for_case with only required parameters."""
+        with patch.object(results_api, "_post") as mock_post:
+            mock_post.return_value = {"id": 1}
+
+            result = results_api.add_result_for_case(run_id=1, case_id=123)
+
+            mock_post.assert_called_once_with(
+                "add_result_for_case/1/123", data={}
+            )
+            assert result == {"id": 1}
+
+    def test_add_result_for_case_with_status_id(
+        self, results_api: ResultsAPI
+    ) -> None:
+        """Test add_result_for_case with status_id provided."""
         with patch.object(results_api, "_post") as mock_post:
             mock_post.return_value = {"id": 1, "status_id": 1}
 
@@ -439,14 +477,14 @@ class TestResultsAPI:
     def test_add_result_for_case_with_none_values(
         self, results_api: ResultsAPI
     ) -> None:
-        """Test add_result_for_case with None values for optional parameters."""
+        """Test add_result_for_case with None values for all parameters."""
         with patch.object(results_api, "_post") as mock_post:
-            mock_post.return_value = {"id": 1, "status_id": 1}
+            mock_post.return_value = {"id": 1}
 
             result = results_api.add_result_for_case(
                 run_id=1,
                 case_id=123,
-                status_id=1,
+                status_id=None,
                 comment=None,
                 version=None,
                 elapsed=None,
@@ -455,11 +493,10 @@ class TestResultsAPI:
                 custom_fields=None,
             )
 
-            expected_data = {"status_id": 1}
             mock_post.assert_called_once_with(
-                "add_result_for_case/1/123", data=expected_data
+                "add_result_for_case/1/123", data={}
             )
-            assert result == {"id": 1, "status_id": 1}
+            assert result == {"id": 1}
 
     def test_add_result_for_case_with_custom_fields(
         self, results_api: ResultsAPI
@@ -651,11 +688,92 @@ class TestResultsAPI:
 
             result = results_api.get_results_for_case(run_id=1, case_id=123)
 
-            mock_get.assert_called_once_with("get_results_for_case/1/123")
+            mock_get.assert_called_once_with(
+                "get_results_for_case/1/123", params={}
+            )
             assert result == [
                 {"id": 1, "status_id": 1, "case_id": 123},
                 {"id": 2, "status_id": 5, "case_id": 123},
             ]
+
+    def test_get_results_for_case_with_all_parameters(
+        self, results_api: ResultsAPI
+    ) -> None:
+        """Test get_results_for_case with all optional filter parameters."""
+        with patch.object(results_api, "_get") as mock_get:
+            mock_get.return_value = [{"id": 1, "status_id": 1}]
+
+            result = results_api.get_results_for_case(
+                run_id=1,
+                case_id=123,
+                defects_filter="TR-1",
+                limit=50,
+                offset=10,
+                status_id=[1, 5],
+            )
+
+            expected_params = {
+                "defects_filter": "TR-1",
+                "limit": 50,
+                "offset": 10,
+                "status_id": "1,5",
+            }
+            mock_get.assert_called_once_with(
+                "get_results_for_case/1/123", params=expected_params
+            )
+            assert result == [{"id": 1, "status_id": 1}]
+
+    def test_get_results_for_case_with_none_values(
+        self, results_api: ResultsAPI
+    ) -> None:
+        """Test get_results_for_case with None values for optional params."""
+        with patch.object(results_api, "_get") as mock_get:
+            mock_get.return_value = []
+
+            results_api.get_results_for_case(
+                run_id=1,
+                case_id=123,
+                defects_filter=None,
+                limit=None,
+                offset=None,
+                status_id=None,
+            )
+
+            mock_get.assert_called_once_with(
+                "get_results_for_case/1/123", params={}
+            )
+
+    def test_get_results_for_case_with_status_id(
+        self, results_api: ResultsAPI
+    ) -> None:
+        """Test get_results_for_case with status_id filter."""
+        with patch.object(results_api, "_get") as mock_get:
+            mock_get.return_value = [{"id": 1}]
+
+            results_api.get_results_for_case(
+                run_id=1, case_id=123, status_id=1
+            )
+
+            expected_params = {"status_id": 1}
+            mock_get.assert_called_once_with(
+                "get_results_for_case/1/123", params=expected_params
+            )
+
+    def test_get_results_for_case_with_pagination(
+        self, results_api: ResultsAPI
+    ) -> None:
+        """Test get_results_for_case with pagination parameters."""
+        with patch.object(results_api, "_get") as mock_get:
+            mock_get.return_value = [{"id": 1}]
+
+            results_api.get_results_for_case(
+                run_id=1, case_id=123, limit=25, offset=50
+            )
+
+            expected_params = {"limit": 25, "offset": 50}
+            mock_get.assert_called_once_with(
+                "get_results_for_case/1/123", params=expected_params
+            )
 
     def test_get_results_for_case_api_error(
         self, results_api: ResultsAPI
@@ -705,7 +823,7 @@ class TestResultsAPI:
             results_api.get_results_for_case(run_id=999999, case_id=999999)
 
             mock_get.assert_called_once_with(
-                "get_results_for_case/999999/999999"
+                "get_results_for_case/999999/999999", params={}
             )
 
     # -------------------------------------------------------------------------

--- a/tests/test_statuses.py
+++ b/tests/test_statuses.py
@@ -38,38 +38,75 @@ class TestStatusesAPI:
         """Create a StatusesAPI instance with mocked client."""
         return StatusesAPI(mock_client)
 
+    @pytest.fixture
+    def sample_statuses_data(self) -> list[dict]:
+        """Sample statuses data for testing."""
+        return [
+            {"id": 1, "name": "passed", "label": "Passed"},
+            {"id": 2, "name": "blocked", "label": "Blocked"},
+            {"id": 3, "name": "untested", "label": "Untested"},
+            {"id": 4, "name": "retest", "label": "Retest"},
+            {"id": 5, "name": "failed", "label": "Failed"},
+        ]
+
+    # -------------------------------------------------------------------------
+    # Initialization
+    # -------------------------------------------------------------------------
+
     def test_init(self, mock_client: Mock) -> None:
         """Test StatusesAPI initialization."""
         api = StatusesAPI(mock_client)
         assert api.client == mock_client
         assert hasattr(api, "logger")
 
-    def test_get_statuses(self, statuses_api: StatusesAPI) -> None:
-        """Test get_statuses method."""
-        with patch.object(statuses_api, "_api_request") as mock_request:
-            mock_request.return_value = [
-                {"id": 1, "name": "Passed"},
-                {"id": 5, "name": "Failed"},
+    # -------------------------------------------------------------------------
+    # get_statuses
+    # -------------------------------------------------------------------------
+
+    def test_get_statuses(
+        self,
+        statuses_api: StatusesAPI,
+        sample_statuses_data: list[dict],
+    ) -> None:
+        """Test get_statuses returns list of status dicts."""
+        with patch.object(statuses_api, "_get") as mock_get:
+            mock_get.return_value = sample_statuses_data
+
+            result = statuses_api.get_statuses()
+
+            mock_get.assert_called_once_with("get_statuses")
+            assert result == sample_statuses_data
+            assert len(result) == 5
+
+    def test_get_statuses_returns_list(
+        self, statuses_api: StatusesAPI
+    ) -> None:
+        """Test get_statuses returns a plain list (no pagination envelope)."""
+        with patch.object(statuses_api, "_get") as mock_get:
+            mock_get.return_value = [
+                {"id": 1, "name": "passed"},
+                {"id": 5, "name": "failed"},
             ]
 
             result = statuses_api.get_statuses()
 
-            mock_request.assert_called_once_with("GET", "get_statuses")
-            assert len(result) == 2
+            assert isinstance(result, list)
             assert result[0]["id"] == 1
 
-    def test_api_request_failure(self, statuses_api: StatusesAPI) -> None:
-        """Test behavior when API request fails."""
-        with patch.object(statuses_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAPIError("API request failed")
+    def test_get_statuses_api_error(self, statuses_api: StatusesAPI) -> None:
+        """Test get_statuses raises TestRailAPIError on API failure."""
+        with patch.object(statuses_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAPIError("API request failed")
 
             with pytest.raises(TestRailAPIError, match="API request failed"):
                 statuses_api.get_statuses()
 
-    def test_authentication_error(self, statuses_api: StatusesAPI) -> None:
-        """Test behavior when authentication fails."""
-        with patch.object(statuses_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAuthenticationError(
+    def test_get_statuses_authentication_error(
+        self, statuses_api: StatusesAPI
+    ) -> None:
+        """Test get_statuses raises TestRailAuthenticationError."""
+        with patch.object(statuses_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAuthenticationError(
                 "Authentication failed"
             )
 
@@ -78,10 +115,12 @@ class TestStatusesAPI:
             ):
                 statuses_api.get_statuses()
 
-    def test_rate_limit_error(self, statuses_api: StatusesAPI) -> None:
-        """Test behavior when rate limit is exceeded."""
-        with patch.object(statuses_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailRateLimitError(
+    def test_get_statuses_rate_limit_error(
+        self, statuses_api: StatusesAPI
+    ) -> None:
+        """Test get_statuses raises TestRailRateLimitError."""
+        with patch.object(statuses_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailRateLimitError(
                 "Rate limit exceeded"
             )
 
@@ -89,3 +128,81 @@ class TestStatusesAPI:
                 TestRailRateLimitError, match="Rate limit exceeded"
             ):
                 statuses_api.get_statuses()
+
+    # -------------------------------------------------------------------------
+    # get_case_statuses
+    # -------------------------------------------------------------------------
+
+    def test_get_case_statuses(self, statuses_api: StatusesAPI) -> None:
+        """Test get_case_statuses returns list of case status dicts."""
+        with patch.object(statuses_api, "_get") as mock_get:
+            mock_get.return_value = [
+                {"id": 1, "name": "open", "label": "Open"},
+                {"id": 2, "name": "in_progress", "label": "In Progress"},
+                {"id": 3, "name": "closed", "label": "Closed"},
+            ]
+
+            result = statuses_api.get_case_statuses()
+
+            mock_get.assert_called_once_with("get_case_statuses")
+            assert len(result) == 3
+            assert result[0]["id"] == 1
+
+    def test_get_case_statuses_returns_list(
+        self, statuses_api: StatusesAPI
+    ) -> None:
+        """Test get_case_statuses returns a plain list."""
+        with patch.object(statuses_api, "_get") as mock_get:
+            mock_get.return_value = [{"id": 1, "name": "open"}]
+
+            result = statuses_api.get_case_statuses()
+
+            assert isinstance(result, list)
+
+    def test_get_case_statuses_empty(self, statuses_api: StatusesAPI) -> None:
+        """Test get_case_statuses with an empty list response."""
+        with patch.object(statuses_api, "_get") as mock_get:
+            mock_get.return_value = []
+
+            result = statuses_api.get_case_statuses()
+
+            mock_get.assert_called_once_with("get_case_statuses")
+            assert result == []
+
+    def test_get_case_statuses_api_error(
+        self, statuses_api: StatusesAPI
+    ) -> None:
+        """Test get_case_statuses raises TestRailAPIError on API failure."""
+        with patch.object(statuses_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAPIError("API request failed")
+
+            with pytest.raises(TestRailAPIError, match="API request failed"):
+                statuses_api.get_case_statuses()
+
+    def test_get_case_statuses_authentication_error(
+        self, statuses_api: StatusesAPI
+    ) -> None:
+        """Test get_case_statuses raises TestRailAuthenticationError."""
+        with patch.object(statuses_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAuthenticationError(
+                "Authentication failed"
+            )
+
+            with pytest.raises(
+                TestRailAuthenticationError, match="Authentication failed"
+            ):
+                statuses_api.get_case_statuses()
+
+    def test_get_case_statuses_rate_limit_error(
+        self, statuses_api: StatusesAPI
+    ) -> None:
+        """Test get_case_statuses raises TestRailRateLimitError."""
+        with patch.object(statuses_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailRateLimitError(
+                "Rate limit exceeded"
+            )
+
+            with pytest.raises(
+                TestRailRateLimitError, match="Rate limit exceeded"
+            ):
+                statuses_api.get_case_statuses()

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -103,26 +103,66 @@ class TestTestsAPI:
                 "get_tests/1", params=expected_params
             )
 
-    def test_get_tests_with_single_label_id(self, tests_api: TestsAPI) -> None:
-        """Test get_tests with single label_id (int)."""
+    def test_get_tests_with_single_assignedto_id(
+        self, tests_api: TestsAPI
+    ) -> None:
+        """Test get_tests with single assignedto_id (int)."""
         with patch.object(tests_api, "_get") as mock_get:
             mock_get.return_value = [{"id": 1}]
 
-            tests_api.get_tests(run_id=1, label_id=1)
+            tests_api.get_tests(run_id=1, assignedto_id=5)
 
-            expected_params = {"label_id": 1}
+            expected_params = {"assignedto_id": 5}
             mock_get.assert_called_once_with(
                 "get_tests/1", params=expected_params
             )
 
-    def test_get_tests_with_list_label_id(self, tests_api: TestsAPI) -> None:
-        """Test get_tests with list label_id."""
+    def test_get_tests_with_list_assignedto_id(
+        self, tests_api: TestsAPI
+    ) -> None:
+        """Test get_tests with list assignedto_id."""
         with patch.object(tests_api, "_get") as mock_get:
             mock_get.return_value = [{"id": 1}]
 
-            tests_api.get_tests(run_id=1, label_id=[1, 2, 3])
+            tests_api.get_tests(run_id=1, assignedto_id=[1, 2, 3])
 
-            expected_params = {"label_id": "1,2,3"}
+            expected_params = {"assignedto_id": "1,2,3"}
+            mock_get.assert_called_once_with(
+                "get_tests/1", params=expected_params
+            )
+
+    def test_get_tests_with_single_case_id(self, tests_api: TestsAPI) -> None:
+        """Test get_tests with single case_id (int)."""
+        with patch.object(tests_api, "_get") as mock_get:
+            mock_get.return_value = [{"id": 1}]
+
+            tests_api.get_tests(run_id=1, case_id=42)
+
+            expected_params = {"case_id": 42}
+            mock_get.assert_called_once_with(
+                "get_tests/1", params=expected_params
+            )
+
+    def test_get_tests_with_list_case_id(self, tests_api: TestsAPI) -> None:
+        """Test get_tests with list case_id."""
+        with patch.object(tests_api, "_get") as mock_get:
+            mock_get.return_value = [{"id": 1}]
+
+            tests_api.get_tests(run_id=1, case_id=[10, 20, 30])
+
+            expected_params = {"case_id": "10,20,30"}
+            mock_get.assert_called_once_with(
+                "get_tests/1", params=expected_params
+            )
+
+    def test_get_tests_with_with_data(self, tests_api: TestsAPI) -> None:
+        """Test get_tests with with_data parameter."""
+        with patch.object(tests_api, "_get") as mock_get:
+            mock_get.return_value = [{"id": 1, "data": {}}]
+
+            tests_api.get_tests(run_id=1, with_data=1)
+
+            expected_params = {"with_data": 1}
             mock_get.assert_called_once_with(
                 "get_tests/1", params=expected_params
             )
@@ -134,21 +174,42 @@ class TestTestsAPI:
 
             tests_api.get_tests(
                 run_id=1,
-                status_id=[1, 5],
+                assignedto_id=[1, 2],
+                case_id=[10, 20],
                 limit=50,
                 offset=10,
-                label_id=[1, 2],
+                status_id=[1, 5],
+                with_data=1,
             )
 
             expected_params = {
-                "status_id": "1,5",
+                "assignedto_id": "1,2",
+                "case_id": "10,20",
                 "limit": 50,
                 "offset": 10,
-                "label_id": "1,2",
+                "status_id": "1,5",
+                "with_data": 1,
             }
             mock_get.assert_called_once_with(
                 "get_tests/1", params=expected_params
             )
+
+    def test_get_tests_with_none_values(self, tests_api: TestsAPI) -> None:
+        """Test get_tests with None values for all optional parameters."""
+        with patch.object(tests_api, "_get") as mock_get:
+            mock_get.return_value = []
+
+            tests_api.get_tests(
+                run_id=1,
+                assignedto_id=None,
+                case_id=None,
+                limit=None,
+                offset=None,
+                status_id=None,
+                with_data=None,
+            )
+
+            mock_get.assert_called_once_with("get_tests/1", params={})
 
     def test_api_request_failure(self, tests_api: TestsAPI) -> None:
         """Test behavior when API request fails."""


### PR DESCRIPTION
## Summary

- **results**: added `defects_filter` to `get_results`; added `defects_filter`, `limit`, `offset`, `status_id` filter params to `get_results_for_case`; made `status_id` optional (was incorrectly required) in `add_result` and `add_result_for_case`
- **tests**: added missing `assignedto_id`, `case_id`, and `with_data` params to `get_tests`; removed non-spec `label_id` param
- **statuses**: switched `get_statuses` and `get_case_statuses` from `_api_request` to `_get` (consistent with all other modules)
- **datasets**: switched all methods from `_api_request` to `_get`/`_post`; replaced `**kwargs` in `update_dataset` with explicit `name` and `variables` params
- All four `.pyi` stubs updated to match
- Test files fully rewritten/expanded: 130 tests across the four modules, 557 total passing

## Test plan

- [x] `uv run pytest tests/test_results.py tests/test_tests.py tests/test_statuses.py tests/test_datasets.py -v` — 130 passed
- [x] `uv run pytest` (full suite) — 557 passed
- [x] `uv run ruff check . --fix && uv run ruff format .` — clean

Closes #147