### PR TITLE
refactor: migrate remaining _api_request calls to _get/_post

### DIFF
--- a/src/testrail_api_module/plans.py
+++ b/src/testrail_api_module/plans.py
@@ -32,7 +32,7 @@ class PlansAPI(BaseAPI):
         Raises:
             TestRailAPIError: If the API request fails.
         """
-        return self._api_request("GET", f"get_plan/{plan_id}")
+        return self._get(f"get_plan/{plan_id}")
 
     def get_plans(
         self,
@@ -86,9 +86,7 @@ class PlansAPI(BaseAPI):
         if offset is not None:
             params["offset"] = offset
 
-        return self._api_request(
-            "GET", f"get_plans/{project_id}", params=params
-        )
+        return self._get(f"get_plans/{project_id}", params=params)
 
     def add_plan(
         self,
@@ -127,7 +125,7 @@ class PlansAPI(BaseAPI):
         if entries:
             data["entries"] = entries
 
-        return self._api_request("POST", f"add_plan/{project_id}", data=data)
+        return self._post(f"add_plan/{project_id}", data=data)
 
     def update_plan(self, plan_id: int, **kwargs: Any) -> dict[str, Any]:
         """
@@ -144,7 +142,7 @@ class PlansAPI(BaseAPI):
         Raises:
             TestRailAPIError: If the API request fails.
         """
-        return self._api_request("POST", f"update_plan/{plan_id}", data=kwargs)
+        return self._post(f"update_plan/{plan_id}", data=kwargs)
 
     def close_plan(self, plan_id: int) -> dict[str, Any]:
         """
@@ -159,7 +157,7 @@ class PlansAPI(BaseAPI):
         Raises:
             TestRailAPIError: If the API request fails.
         """
-        return self._api_request("POST", f"close_plan/{plan_id}")
+        return self._post(f"close_plan/{plan_id}")
 
     def delete_plan(self, plan_id: int) -> dict[str, Any]:
         """
@@ -174,7 +172,7 @@ class PlansAPI(BaseAPI):
         Raises:
             TestRailAPIError: If the API request fails.
         """
-        return self._api_request("POST", f"delete_plan/{plan_id}")
+        return self._post(f"delete_plan/{plan_id}")
 
     def add_plan_entry(
         self,
@@ -228,9 +226,7 @@ class PlansAPI(BaseAPI):
         if runs is not None:
             data["runs"] = runs
 
-        return self._api_request(
-            "POST", f"add_plan_entry/{plan_id}", data=data
-        )
+        return self._post(f"add_plan_entry/{plan_id}", data=data)
 
     def update_plan_entry(
         self, plan_id: int, entry_id: str, **kwargs: Any
@@ -250,8 +246,7 @@ class PlansAPI(BaseAPI):
         Raises:
             TestRailAPIError: If the API request fails.
         """
-        return self._api_request(
-            "POST",
+        return self._post(
             f"update_plan_entry/{plan_id}/{entry_id}",
             data=kwargs,
         )
@@ -270,10 +265,7 @@ class PlansAPI(BaseAPI):
         Raises:
             TestRailAPIError: If the API request fails.
         """
-        return self._api_request(
-            "POST",
-            f"delete_plan_entry/{plan_id}/{entry_id}",
-        )
+        return self._post(f"delete_plan_entry/{plan_id}/{entry_id}")
 
     def add_run_to_plan_entry(
         self,
@@ -324,8 +316,7 @@ class PlansAPI(BaseAPI):
         if refs is not None:
             data["refs"] = refs
 
-        return self._api_request(
-            "POST",
+        return self._post(
             f"add_run_to_plan_entry/{plan_id}/{entry_id}",
             data=data,
         )
@@ -373,8 +364,7 @@ class PlansAPI(BaseAPI):
         if refs is not None:
             data["refs"] = refs
 
-        return self._api_request(
-            "POST",
+        return self._post(
             f"update_run_in_plan_entry/{run_id}",
             data=data,
         )
@@ -394,7 +384,4 @@ class PlansAPI(BaseAPI):
         Raises:
             TestRailAPIError: If the API request fails.
         """
-        return self._api_request(
-            "POST",
-            f"delete_run_from_plan_entry/{run_id}",
-        )
+        return self._post(f"delete_run_from_plan_entry/{run_id}")

--- a/src/testrail_api_module/priorities.py
+++ b/src/testrail_api_module/priorities.py
@@ -28,4 +28,4 @@ class PrioritiesAPI(BaseAPI):
         Raises:
             TestRailAPIError: If the API request fails.
         """
-        return self._api_request("GET", "get_priorities")
+        return self._get("get_priorities")

--- a/src/testrail_api_module/result_fields.py
+++ b/src/testrail_api_module/result_fields.py
@@ -29,4 +29,4 @@ class ResultFieldsAPI(BaseAPI):
         Raises:
             TestRailAPIError: If the API request fails.
         """
-        return self._api_request("GET", "get_result_fields")
+        return self._get("get_result_fields")

--- a/src/testrail_api_module/roles.py
+++ b/src/testrail_api_module/roles.py
@@ -28,4 +28,4 @@ class RolesAPI(BaseAPI):
         Raises:
             TestRailAPIError: If the API request fails.
         """
-        return self._api_request("GET", "get_roles")
+        return self._get("get_roles")

--- a/src/testrail_api_module/templates.py
+++ b/src/testrail_api_module/templates.py
@@ -31,4 +31,4 @@ class TemplatesAPI(BaseAPI):
         Raises:
             TestRailAPIError: If the API request fails.
         """
-        return self._api_request("GET", f"get_templates/{project_id}")
+        return self._get(f"get_templates/{project_id}")

--- a/src/testrail_api_module/users.py
+++ b/src/testrail_api_module/users.py
@@ -32,7 +32,7 @@ class UsersAPI(BaseAPI):
         Raises:
             TestRailAPIError: If the API request fails.
         """
-        return self._api_request("GET", f"get_user/{user_id}")
+        return self._get(f"get_user/{user_id}")
 
     def get_users(self, project_id: int | None = None) -> list[dict[str, Any]]:
         """
@@ -53,7 +53,7 @@ class UsersAPI(BaseAPI):
         endpoint = "get_users"
         if project_id is not None:
             endpoint = f"get_users/{project_id}"
-        return self._api_request("GET", endpoint)
+        return self._get(endpoint)
 
     def get_current_user(self) -> dict[str, Any]:
         """
@@ -67,7 +67,7 @@ class UsersAPI(BaseAPI):
         Raises:
             TestRailAPIError: If the API request fails.
         """
-        return self._api_request("GET", "get_current_user")
+        return self._get("get_current_user")
 
     def get_user_by_email(self, email: str) -> dict[str, Any]:
         """
@@ -82,6 +82,4 @@ class UsersAPI(BaseAPI):
         Raises:
             TestRailAPIError: If the API request fails.
         """
-        return self._api_request(
-            "GET", "get_user_by_email", params={"email": email}
-        )
+        return self._get("get_user_by_email", params={"email": email})

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -46,17 +46,17 @@ class TestPlansAPI:
 
     def test_get_plan(self, plans_api: PlansAPI) -> None:
         """Test get_plan method."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.return_value = {"id": 1, "name": "Test Plan"}
+        with patch.object(plans_api, "_get") as mock_get:
+            mock_get.return_value = {"id": 1, "name": "Test Plan"}
 
             result = plans_api.get_plan(plan_id=1)
 
-            mock_request.assert_called_once_with("GET", "get_plan/1")
+            mock_get.assert_called_once_with("get_plan/1")
             assert result == {"id": 1, "name": "Test Plan"}
 
     def test_get_plans(self, plans_api: PlansAPI) -> None:
         """Test get_plans with minimal required parameters."""
-        with patch.object(plans_api, "_api_request") as mock_request:
+        with patch.object(plans_api, "_get") as mock_get:
             envelope = {
                 "offset": 0,
                 "limit": 250,
@@ -67,19 +67,17 @@ class TestPlansAPI:
                     {"id": 2, "name": "Plan 2"},
                 ],
             }
-            mock_request.return_value = envelope
+            mock_get.return_value = envelope
 
             result = plans_api.get_plans(project_id=1)
 
-            mock_request.assert_called_once_with(
-                "GET", "get_plans/1", params={}
-            )
+            mock_get.assert_called_once_with("get_plans/1", params={})
             assert result == envelope
             assert len(result["plans"]) == 2
 
     def test_get_plans_with_all_parameters(self, plans_api: PlansAPI) -> None:
         """Test get_plans with all optional filter parameters."""
-        with patch.object(plans_api, "_api_request") as mock_request:
+        with patch.object(plans_api, "_get") as mock_get:
             envelope = {
                 "offset": 0,
                 "limit": 10,
@@ -87,7 +85,7 @@ class TestPlansAPI:
                 "_links": {"next": None, "prev": None},
                 "plans": [{"id": 1, "name": "Plan 1"}],
             }
-            mock_request.return_value = envelope
+            mock_get.return_value = envelope
 
             result = plans_api.get_plans(
                 project_id=1,
@@ -109,14 +107,14 @@ class TestPlansAPI:
                 "limit": 10,
                 "offset": 0,
             }
-            mock_request.assert_called_once_with(
-                "GET", "get_plans/1", params=expected_params
+            mock_get.assert_called_once_with(
+                "get_plans/1", params=expected_params
             )
             assert result == envelope
 
     def test_get_plans_with_none_values(self, plans_api: PlansAPI) -> None:
         """Test get_plans with None values for optional parameters."""
-        with patch.object(plans_api, "_api_request") as mock_request:
+        with patch.object(plans_api, "_get") as mock_get:
             envelope = {
                 "offset": 0,
                 "limit": 250,
@@ -124,7 +122,7 @@ class TestPlansAPI:
                 "_links": {"next": None, "prev": None},
                 "plans": [{"id": 1}],
             }
-            mock_request.return_value = envelope
+            mock_get.return_value = envelope
 
             result = plans_api.get_plans(
                 project_id=1,
@@ -137,28 +135,24 @@ class TestPlansAPI:
                 offset=None,
             )
 
-            mock_request.assert_called_once_with(
-                "GET", "get_plans/1", params={}
-            )
+            mock_get.assert_called_once_with("get_plans/1", params={})
             assert result == envelope
 
     def test_add_plan_minimal(self, plans_api: PlansAPI) -> None:
         """Test add_plan with minimal required parameters."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.return_value = {"id": 1, "name": "New Plan"}
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.return_value = {"id": 1, "name": "New Plan"}
 
             result = plans_api.add_plan(project_id=1, name="New Plan")
 
             expected_data = {"name": "New Plan"}
-            mock_request.assert_called_once_with(
-                "POST", "add_plan/1", data=expected_data
-            )
+            mock_post.assert_called_once_with("add_plan/1", data=expected_data)
             assert result == {"id": 1, "name": "New Plan"}
 
     def test_add_plan_with_all_parameters(self, plans_api: PlansAPI) -> None:
         """Test add_plan with all optional parameters."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.return_value = {"id": 1, "name": "New Plan"}
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.return_value = {"id": 1, "name": "New Plan"}
 
             entries = [
                 {"suite_id": 1, "name": "Test Run", "include_all": True}
@@ -178,14 +172,12 @@ class TestPlansAPI:
                 "milestone_id": 2,
                 "entries": entries,
             }
-            mock_request.assert_called_once_with(
-                "POST", "add_plan/1", data=expected_data
-            )
+            mock_post.assert_called_once_with("add_plan/1", data=expected_data)
 
     def test_add_plan_with_none_values(self, plans_api: PlansAPI) -> None:
         """Test add_plan with None values."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.return_value = {"id": 1, "name": "New Plan"}
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.return_value = {"id": 1, "name": "New Plan"}
 
             plans_api.add_plan(
                 project_id=1,
@@ -196,14 +188,12 @@ class TestPlansAPI:
             )
 
             expected_data = {"name": "New Plan"}
-            mock_request.assert_called_once_with(
-                "POST", "add_plan/1", data=expected_data
-            )
+            mock_post.assert_called_once_with("add_plan/1", data=expected_data)
 
     def test_update_plan(self, plans_api: PlansAPI) -> None:
         """Test update_plan method."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.return_value = {"id": 1, "name": "Updated Plan"}
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.return_value = {"id": 1, "name": "Updated Plan"}
 
             plans_api.update_plan(
                 plan_id=1,
@@ -215,40 +205,40 @@ class TestPlansAPI:
                 "name": "Updated Plan",
                 "description": "Updated description",
             }
-            mock_request.assert_called_once_with(
-                "POST", "update_plan/1", data=expected_data
+            mock_post.assert_called_once_with(
+                "update_plan/1", data=expected_data
             )
 
     def test_close_plan(self, plans_api: PlansAPI) -> None:
         """Test close_plan method."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.return_value = {}
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.return_value = {}
 
             result = plans_api.close_plan(plan_id=1)
 
-            mock_request.assert_called_once_with("POST", "close_plan/1")
+            mock_post.assert_called_once_with("close_plan/1")
             assert result == {}
 
     def test_delete_plan(self, plans_api: PlansAPI) -> None:
         """Test delete_plan method."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.return_value = {}
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.return_value = {}
 
             result = plans_api.delete_plan(plan_id=1)
 
-            mock_request.assert_called_once_with("POST", "delete_plan/1")
+            mock_post.assert_called_once_with("delete_plan/1")
             assert result == {}
 
     def test_add_plan_entry_minimal(self, plans_api: PlansAPI) -> None:
         """Test add_plan_entry with minimal required parameters."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.return_value = {"id": 10, "suite_id": 5}
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.return_value = {"id": 10, "suite_id": 5}
 
             result = plans_api.add_plan_entry(plan_id=1, suite_id=5)
 
             expected_data = {"suite_id": 5, "include_all": True}
-            mock_request.assert_called_once_with(
-                "POST", "add_plan_entry/1", data=expected_data
+            mock_post.assert_called_once_with(
+                "add_plan_entry/1", data=expected_data
             )
             assert result == {"id": 10, "suite_id": 5}
 
@@ -256,8 +246,8 @@ class TestPlansAPI:
         self, plans_api: PlansAPI
     ) -> None:
         """Test add_plan_entry with all optional parameters."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.return_value = {"id": 10, "suite_id": 5}
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.return_value = {"id": 10, "suite_id": 5}
 
             runs = [{"config_ids": [1, 2], "include_all": True}]
 
@@ -283,8 +273,8 @@ class TestPlansAPI:
                 "config_ids": [1, 2],
                 "runs": runs,
             }
-            mock_request.assert_called_once_with(
-                "POST", "add_plan_entry/1", data=expected_data
+            mock_post.assert_called_once_with(
+                "add_plan_entry/1", data=expected_data
             )
             assert result == {"id": 10, "suite_id": 5}
 
@@ -292,8 +282,8 @@ class TestPlansAPI:
         self, plans_api: PlansAPI
     ) -> None:
         """Test add_plan_entry excludes None optional fields from data."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.return_value = {"id": 10, "suite_id": 5}
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.return_value = {"id": 10, "suite_id": 5}
 
             result = plans_api.add_plan_entry(
                 plan_id=1,
@@ -307,8 +297,8 @@ class TestPlansAPI:
             )
 
             expected_data = {"suite_id": 5, "include_all": True}
-            mock_request.assert_called_once_with(
-                "POST", "add_plan_entry/1", data=expected_data
+            mock_post.assert_called_once_with(
+                "add_plan_entry/1", data=expected_data
             )
             assert result == {"id": 10, "suite_id": 5}
 
@@ -320,18 +310,17 @@ class TestPlansAPI:
         Regression test for #101: include_all=True used to be silently
         dropped from the payload.
         """
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.return_value = {"id": 10, "suite_id": 5}
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.return_value = {"id": 10, "suite_id": 5}
 
             result = plans_api.add_plan_entry(
                 plan_id=1, suite_id=5, include_all=True
             )
 
-            call_args = mock_request.call_args
+            call_args = mock_post.call_args
             data_sent = call_args[1]["data"]
             assert data_sent["include_all"] is True
-            mock_request.assert_called_once_with(
-                "POST",
+            mock_post.assert_called_once_with(
                 "add_plan_entry/1",
                 data={"suite_id": 5, "include_all": True},
             )
@@ -341,15 +330,14 @@ class TestPlansAPI:
         self, plans_api: PlansAPI
     ) -> None:
         """Test add_plan_entry sends include_all when it is False."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.return_value = {"id": 10, "suite_id": 5}
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.return_value = {"id": 10, "suite_id": 5}
 
             result = plans_api.add_plan_entry(
                 plan_id=1, suite_id=5, include_all=False, case_ids=[1, 2]
             )
 
-            mock_request.assert_called_once_with(
-                "POST",
+            mock_post.assert_called_once_with(
                 "add_plan_entry/1",
                 data={
                     "suite_id": 5,
@@ -361,8 +349,8 @@ class TestPlansAPI:
 
     def test_update_plan_entry(self, plans_api: PlansAPI) -> None:
         """Test update_plan_entry with keyword arguments."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.return_value = {
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.return_value = {
                 "id": 10,
                 "name": "Updated Entry",
             }
@@ -380,8 +368,7 @@ class TestPlansAPI:
                 "include_all": False,
                 "case_ids": [201, 202],
             }
-            mock_request.assert_called_once_with(
-                "POST",
+            mock_post.assert_called_once_with(
                 "update_plan_entry/1/abc-123",
                 data=expected_data,
             )
@@ -389,42 +376,39 @@ class TestPlansAPI:
 
     def test_update_plan_entry_no_kwargs(self, plans_api: PlansAPI) -> None:
         """Test update_plan_entry with no keyword arguments sends empty data."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.return_value = {}
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.return_value = {}
 
             result = plans_api.update_plan_entry(
                 plan_id=2, entry_id="entry-99"
             )
 
-            mock_request.assert_called_once_with(
-                "POST", "update_plan_entry/2/entry-99", data={}
+            mock_post.assert_called_once_with(
+                "update_plan_entry/2/entry-99", data={}
             )
             assert result == {}
 
     def test_delete_plan_entry(self, plans_api: PlansAPI) -> None:
         """Test delete_plan_entry sends POST with correct endpoint."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.return_value = {}
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.return_value = {}
 
             result = plans_api.delete_plan_entry(plan_id=1, entry_id="abc-123")
 
-            mock_request.assert_called_once_with(
-                "POST", "delete_plan_entry/1/abc-123"
-            )
+            mock_post.assert_called_once_with("delete_plan_entry/1/abc-123")
             assert result == {}
 
     def test_add_run_to_plan_entry_minimal(self, plans_api: PlansAPI) -> None:
         """Test add_run_to_plan_entry with minimal required parameters."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.return_value = {"id": "abc-123", "runs": []}
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.return_value = {"id": "abc-123", "runs": []}
 
             result = plans_api.add_run_to_plan_entry(
                 plan_id=1, entry_id="abc-123", config_ids=[1, 5]
             )
 
             expected_data = {"config_ids": [1, 5], "include_all": True}
-            mock_request.assert_called_once_with(
-                "POST",
+            mock_post.assert_called_once_with(
                 "add_run_to_plan_entry/1/abc-123",
                 data=expected_data,
             )
@@ -434,8 +418,8 @@ class TestPlansAPI:
         self, plans_api: PlansAPI
     ) -> None:
         """Test add_run_to_plan_entry with all optional parameters."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.return_value = {"id": "abc-123", "runs": []}
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.return_value = {"id": "abc-123", "runs": []}
 
             result = plans_api.add_run_to_plan_entry(
                 plan_id=1,
@@ -456,8 +440,7 @@ class TestPlansAPI:
                 "case_ids": [1, 2, 4],
                 "refs": "JIRA-1",
             }
-            mock_request.assert_called_once_with(
-                "POST",
+            mock_post.assert_called_once_with(
                 "add_run_to_plan_entry/1/abc-123",
                 data=expected_data,
             )
@@ -467,8 +450,8 @@ class TestPlansAPI:
         self, plans_api: PlansAPI
     ) -> None:
         """Test add_run_to_plan_entry excludes None optional fields."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.return_value = {"id": "abc-123", "runs": []}
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.return_value = {"id": "abc-123", "runs": []}
 
             result = plans_api.add_run_to_plan_entry(
                 plan_id=1,
@@ -481,8 +464,7 @@ class TestPlansAPI:
             )
 
             expected_data = {"config_ids": [1], "include_all": True}
-            mock_request.assert_called_once_with(
-                "POST",
+            mock_post.assert_called_once_with(
                 "add_run_to_plan_entry/1/abc-123",
                 data=expected_data,
             )
@@ -492,8 +474,8 @@ class TestPlansAPI:
         self, plans_api: PlansAPI
     ) -> None:
         """Test add_run_to_plan_entry raises TestRailAPIError."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAPIError("API request failed")
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.side_effect = TestRailAPIError("API request failed")
 
             with pytest.raises(TestRailAPIError, match="API request failed"):
                 plans_api.add_run_to_plan_entry(
@@ -504,8 +486,8 @@ class TestPlansAPI:
         self, plans_api: PlansAPI
     ) -> None:
         """Test add_run_to_plan_entry raises authentication error."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAuthenticationError(
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.side_effect = TestRailAuthenticationError(
                 "Authentication failed"
             )
 
@@ -520,8 +502,8 @@ class TestPlansAPI:
         self, plans_api: PlansAPI
     ) -> None:
         """Test add_run_to_plan_entry raises rate limit error."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailRateLimitError(
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.side_effect = TestRailRateLimitError(
                 "Rate limit exceeded"
             )
 
@@ -536,13 +518,13 @@ class TestPlansAPI:
         self, plans_api: PlansAPI
     ) -> None:
         """Test update_run_in_plan_entry with only run_id."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.return_value = {"id": 81}
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.return_value = {"id": 81}
 
             result = plans_api.update_run_in_plan_entry(run_id=81)
 
-            mock_request.assert_called_once_with(
-                "POST", "update_run_in_plan_entry/81", data={}
+            mock_post.assert_called_once_with(
+                "update_run_in_plan_entry/81", data={}
             )
             assert result == {"id": 81}
 
@@ -550,8 +532,8 @@ class TestPlansAPI:
         self, plans_api: PlansAPI
     ) -> None:
         """Test update_run_in_plan_entry with all optional parameters."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.return_value = {"id": 81, "include_all": False}
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.return_value = {"id": 81, "include_all": False}
 
             result = plans_api.update_run_in_plan_entry(
                 run_id=81,
@@ -569,8 +551,8 @@ class TestPlansAPI:
                 "case_ids": [1, 2, 4],
                 "refs": "JIRA-2",
             }
-            mock_request.assert_called_once_with(
-                "POST", "update_run_in_plan_entry/81", data=expected_data
+            mock_post.assert_called_once_with(
+                "update_run_in_plan_entry/81", data=expected_data
             )
             assert result == {"id": 81, "include_all": False}
 
@@ -578,8 +560,8 @@ class TestPlansAPI:
         self, plans_api: PlansAPI
     ) -> None:
         """Test update_run_in_plan_entry excludes None fields."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.return_value = {"id": 81}
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.return_value = {"id": 81}
 
             result = plans_api.update_run_in_plan_entry(
                 run_id=81,
@@ -590,8 +572,8 @@ class TestPlansAPI:
                 refs=None,
             )
 
-            mock_request.assert_called_once_with(
-                "POST", "update_run_in_plan_entry/81", data={}
+            mock_post.assert_called_once_with(
+                "update_run_in_plan_entry/81", data={}
             )
             assert result == {"id": 81}
 
@@ -599,15 +581,14 @@ class TestPlansAPI:
         self, plans_api: PlansAPI
     ) -> None:
         """Test update_run_in_plan_entry sends include_all when True."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.return_value = {"id": 81, "include_all": True}
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.return_value = {"id": 81, "include_all": True}
 
             result = plans_api.update_run_in_plan_entry(
                 run_id=81, include_all=True
             )
 
-            mock_request.assert_called_once_with(
-                "POST",
+            mock_post.assert_called_once_with(
                 "update_run_in_plan_entry/81",
                 data={"include_all": True},
             )
@@ -617,8 +598,8 @@ class TestPlansAPI:
         self, plans_api: PlansAPI
     ) -> None:
         """Test update_run_in_plan_entry raises TestRailAPIError."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAPIError("API request failed")
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.side_effect = TestRailAPIError("API request failed")
 
             with pytest.raises(TestRailAPIError, match="API request failed"):
                 plans_api.update_run_in_plan_entry(run_id=81)
@@ -627,8 +608,8 @@ class TestPlansAPI:
         self, plans_api: PlansAPI
     ) -> None:
         """Test update_run_in_plan_entry raises authentication error."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAuthenticationError(
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.side_effect = TestRailAuthenticationError(
                 "Authentication failed"
             )
 
@@ -641,8 +622,8 @@ class TestPlansAPI:
         self, plans_api: PlansAPI
     ) -> None:
         """Test update_run_in_plan_entry raises rate limit error."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailRateLimitError(
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.side_effect = TestRailRateLimitError(
                 "Rate limit exceeded"
             )
 
@@ -653,22 +634,20 @@ class TestPlansAPI:
 
     def test_delete_run_from_plan_entry(self, plans_api: PlansAPI) -> None:
         """Test delete_run_from_plan_entry sends POST to the endpoint."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.return_value = {}
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.return_value = {}
 
             result = plans_api.delete_run_from_plan_entry(run_id=81)
 
-            mock_request.assert_called_once_with(
-                "POST", "delete_run_from_plan_entry/81"
-            )
+            mock_post.assert_called_once_with("delete_run_from_plan_entry/81")
             assert result == {}
 
     def test_delete_run_from_plan_entry_api_error(
         self, plans_api: PlansAPI
     ) -> None:
         """Test delete_run_from_plan_entry raises TestRailAPIError."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAPIError("API request failed")
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.side_effect = TestRailAPIError("API request failed")
 
             with pytest.raises(TestRailAPIError, match="API request failed"):
                 plans_api.delete_run_from_plan_entry(run_id=81)
@@ -677,8 +656,8 @@ class TestPlansAPI:
         self, plans_api: PlansAPI
     ) -> None:
         """Test delete_run_from_plan_entry raises authentication error."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAuthenticationError(
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.side_effect = TestRailAuthenticationError(
                 "Authentication failed"
             )
 
@@ -691,8 +670,8 @@ class TestPlansAPI:
         self, plans_api: PlansAPI
     ) -> None:
         """Test delete_run_from_plan_entry raises rate limit error."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailRateLimitError(
+        with patch.object(plans_api, "_post") as mock_post:
+            mock_post.side_effect = TestRailRateLimitError(
                 "Rate limit exceeded"
             )
 
@@ -703,16 +682,16 @@ class TestPlansAPI:
 
     def test_api_request_failure(self, plans_api: PlansAPI) -> None:
         """Test behavior when API request fails."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAPIError("API request failed")
+        with patch.object(plans_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAPIError("API request failed")
 
             with pytest.raises(TestRailAPIError, match="API request failed"):
                 plans_api.get_plan(plan_id=1)
 
     def test_authentication_error(self, plans_api: PlansAPI) -> None:
         """Test behavior when authentication fails."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAuthenticationError(
+        with patch.object(plans_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAuthenticationError(
                 "Authentication failed"
             )
 
@@ -723,8 +702,8 @@ class TestPlansAPI:
 
     def test_rate_limit_error(self, plans_api: PlansAPI) -> None:
         """Test behavior when rate limit is exceeded."""
-        with patch.object(plans_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailRateLimitError(
+        with patch.object(plans_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailRateLimitError(
                 "Rate limit exceeded"
             )
 

--- a/tests/test_priorities.py
+++ b/tests/test_priorities.py
@@ -46,8 +46,8 @@ class TestPrioritiesAPI:
 
     def test_get_priorities(self, priorities_api: PrioritiesAPI) -> None:
         """Test get_priorities method."""
-        with patch.object(priorities_api, "_api_request") as mock_request:
-            mock_request.return_value = [
+        with patch.object(priorities_api, "_get") as mock_get:
+            mock_get.return_value = [
                 {"id": 1, "name": "High"},
                 {"id": 2, "name": "Medium"},
                 {"id": 3, "name": "Low"},
@@ -55,22 +55,22 @@ class TestPrioritiesAPI:
 
             result = priorities_api.get_priorities()
 
-            mock_request.assert_called_once_with("GET", "get_priorities")
+            mock_get.assert_called_once_with("get_priorities")
             assert len(result) == 3
             assert result[0]["id"] == 1
 
     def test_api_request_failure(self, priorities_api: PrioritiesAPI) -> None:
         """Test behavior when API request fails."""
-        with patch.object(priorities_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAPIError("API request failed")
+        with patch.object(priorities_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAPIError("API request failed")
 
             with pytest.raises(TestRailAPIError, match="API request failed"):
                 priorities_api.get_priorities()
 
     def test_authentication_error(self, priorities_api: PrioritiesAPI) -> None:
         """Test behavior when authentication fails."""
-        with patch.object(priorities_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAuthenticationError(
+        with patch.object(priorities_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAuthenticationError(
                 "Authentication failed"
             )
 
@@ -81,8 +81,8 @@ class TestPrioritiesAPI:
 
     def test_rate_limit_error(self, priorities_api: PrioritiesAPI) -> None:
         """Test behavior when rate limit is exceeded."""
-        with patch.object(priorities_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailRateLimitError(
+        with patch.object(priorities_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailRateLimitError(
                 "Rate limit exceeded"
             )
 

--- a/tests/test_result_fields.py
+++ b/tests/test_result_fields.py
@@ -48,15 +48,15 @@ class TestResultFieldsAPI:
         self, result_fields_api: ResultFieldsAPI
     ) -> None:
         """Test get_result_fields method."""
-        with patch.object(result_fields_api, "_api_request") as mock_request:
-            mock_request.return_value = [
+        with patch.object(result_fields_api, "_get") as mock_get:
+            mock_get.return_value = [
                 {"id": 1, "name": "Field 1"},
                 {"id": 2, "name": "Field 2"},
             ]
 
             result = result_fields_api.get_result_fields()
 
-            mock_request.assert_called_once_with("GET", "get_result_fields")
+            mock_get.assert_called_once_with("get_result_fields")
             assert len(result) == 2
             assert result[0]["id"] == 1
 
@@ -64,8 +64,8 @@ class TestResultFieldsAPI:
         self, result_fields_api: ResultFieldsAPI
     ) -> None:
         """Test behavior when API request fails."""
-        with patch.object(result_fields_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAPIError("API request failed")
+        with patch.object(result_fields_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAPIError("API request failed")
 
             with pytest.raises(TestRailAPIError, match="API request failed"):
                 result_fields_api.get_result_fields()
@@ -74,8 +74,8 @@ class TestResultFieldsAPI:
         self, result_fields_api: ResultFieldsAPI
     ) -> None:
         """Test behavior when authentication fails."""
-        with patch.object(result_fields_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAuthenticationError(
+        with patch.object(result_fields_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAuthenticationError(
                 "Authentication failed"
             )
 
@@ -88,8 +88,8 @@ class TestResultFieldsAPI:
         self, result_fields_api: ResultFieldsAPI
     ) -> None:
         """Test behavior when rate limit is exceeded."""
-        with patch.object(result_fields_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailRateLimitError(
+        with patch.object(result_fields_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailRateLimitError(
                 "Rate limit exceeded"
             )
 

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -46,29 +46,29 @@ class TestRolesAPI:
 
     def test_get_roles(self, roles_api: RolesAPI) -> None:
         """Test get_roles method."""
-        with patch.object(roles_api, "_api_request") as mock_request:
-            mock_request.return_value = [
+        with patch.object(roles_api, "_get") as mock_get:
+            mock_get.return_value = [
                 {"id": 1, "name": "Admin"},
                 {"id": 2, "name": "User"},
             ]
 
             result = roles_api.get_roles()
 
-            mock_request.assert_called_once_with("GET", "get_roles")
+            mock_get.assert_called_once_with("get_roles")
             assert len(result) == 2
 
     def test_api_request_failure(self, roles_api: RolesAPI) -> None:
         """Test behavior when API request fails."""
-        with patch.object(roles_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAPIError("API request failed")
+        with patch.object(roles_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAPIError("API request failed")
 
             with pytest.raises(TestRailAPIError, match="API request failed"):
                 roles_api.get_roles()
 
     def test_authentication_error(self, roles_api: RolesAPI) -> None:
         """Test behavior when authentication fails."""
-        with patch.object(roles_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAuthenticationError(
+        with patch.object(roles_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAuthenticationError(
                 "Authentication failed"
             )
 
@@ -79,8 +79,8 @@ class TestRolesAPI:
 
     def test_rate_limit_error(self, roles_api: RolesAPI) -> None:
         """Test behavior when rate limit is exceeded."""
-        with patch.object(roles_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailRateLimitError(
+        with patch.object(roles_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailRateLimitError(
                 "Rate limit exceeded"
             )
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -46,28 +46,28 @@ class TestTemplatesAPI:
 
     def test_get_templates(self, templates_api: TemplatesAPI) -> None:
         """Test get_templates method."""
-        with patch.object(templates_api, "_api_request") as mock_request:
-            mock_request.return_value = [
+        with patch.object(templates_api, "_get") as mock_get:
+            mock_get.return_value = [
                 {"id": 1, "name": "Template 1"},
                 {"id": 2, "name": "Template 2"},
             ]
 
             result = templates_api.get_templates(project_id=1)
-            mock_request.assert_called_once_with("GET", "get_templates/1")
+            mock_get.assert_called_once_with("get_templates/1")
             assert len(result) == 2
 
     def test_api_request_failure(self, templates_api: TemplatesAPI) -> None:
         """Test behavior when API request fails."""
-        with patch.object(templates_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAPIError("API request failed")
+        with patch.object(templates_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAPIError("API request failed")
 
             with pytest.raises(TestRailAPIError, match="API request failed"):
                 templates_api.get_templates(project_id=1)
 
     def test_authentication_error(self, templates_api: TemplatesAPI) -> None:
         """Test behavior when authentication fails."""
-        with patch.object(templates_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAuthenticationError(
+        with patch.object(templates_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAuthenticationError(
                 "Authentication failed"
             )
 
@@ -78,8 +78,8 @@ class TestTemplatesAPI:
 
     def test_rate_limit_error(self, templates_api: TemplatesAPI) -> None:
         """Test behavior when rate limit is exceeded."""
-        with patch.object(templates_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailRateLimitError(
+        with patch.object(templates_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailRateLimitError(
                 "Rate limit exceeded"
             )
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -59,46 +59,46 @@ class TestUsersAPI:
         self, users_api: UsersAPI, sample_user_data: dict
     ) -> None:
         """Test get_user method."""
-        with patch.object(users_api, "_api_request") as mock_request:
-            mock_request.return_value = sample_user_data
+        with patch.object(users_api, "_get") as mock_get:
+            mock_get.return_value = sample_user_data
 
             result = users_api.get_user(user_id=1)
 
-            mock_request.assert_called_once_with("GET", "get_user/1")
+            mock_get.assert_called_once_with("get_user/1")
             assert result == sample_user_data
 
     def test_get_users_minimal(self, users_api: UsersAPI) -> None:
         """Test get_users with minimal required parameters."""
-        with patch.object(users_api, "_api_request") as mock_request:
-            mock_request.return_value = [
+        with patch.object(users_api, "_get") as mock_get:
+            mock_get.return_value = [
                 {"id": 1, "name": "User 1"},
                 {"id": 2, "name": "User 2"},
             ]
 
             result = users_api.get_users()
 
-            mock_request.assert_called_once_with("GET", "get_users")
+            mock_get.assert_called_once_with("get_users")
             assert len(result) == 2
             assert result[0]["id"] == 1
 
     def test_get_users_with_project_id(self, users_api: UsersAPI) -> None:
         """Test get_users with the optional project_id parameter."""
-        with patch.object(users_api, "_api_request") as mock_request:
-            mock_request.return_value = [{"id": 1, "name": "User 1"}]
+        with patch.object(users_api, "_get") as mock_get:
+            mock_get.return_value = [{"id": 1, "name": "User 1"}]
 
             result = users_api.get_users(project_id=5)
 
-            mock_request.assert_called_once_with("GET", "get_users/5")
+            mock_get.assert_called_once_with("get_users/5")
             assert result == [{"id": 1, "name": "User 1"}]
 
     def test_get_users_with_none_project_id(self, users_api: UsersAPI) -> None:
         """Test get_users with project_id explicitly set to None."""
-        with patch.object(users_api, "_api_request") as mock_request:
-            mock_request.return_value = [{"id": 1, "name": "User 1"}]
+        with patch.object(users_api, "_get") as mock_get:
+            mock_get.return_value = [{"id": 1, "name": "User 1"}]
 
             result = users_api.get_users(project_id=None)
 
-            mock_request.assert_called_once_with("GET", "get_users")
+            mock_get.assert_called_once_with("get_users")
             assert result == [{"id": 1, "name": "User 1"}]
 
     @pytest.mark.parametrize("project_id", [1, 42, 999999])
@@ -106,28 +106,26 @@ class TestUsersAPI:
         self, users_api: UsersAPI, project_id: int
     ) -> None:
         """Test get_users builds the endpoint for different project IDs."""
-        with patch.object(users_api, "_api_request") as mock_request:
-            mock_request.return_value = []
+        with patch.object(users_api, "_get") as mock_get:
+            mock_get.return_value = []
 
             result = users_api.get_users(project_id=project_id)
 
-            mock_request.assert_called_once_with(
-                "GET", f"get_users/{project_id}"
-            )
+            mock_get.assert_called_once_with(f"get_users/{project_id}")
             assert result == []
 
     def test_get_users_api_request_failure(self, users_api: UsersAPI) -> None:
         """Test get_users behavior when API request fails."""
-        with patch.object(users_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAPIError("API request failed")
+        with patch.object(users_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAPIError("API request failed")
 
             with pytest.raises(TestRailAPIError, match="API request failed"):
                 users_api.get_users()
 
     def test_get_users_authentication_error(self, users_api: UsersAPI) -> None:
         """Test get_users behavior when authentication fails."""
-        with patch.object(users_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAuthenticationError(
+        with patch.object(users_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAuthenticationError(
                 "Authentication failed"
             )
 
@@ -138,8 +136,8 @@ class TestUsersAPI:
 
     def test_get_users_rate_limit_error(self, users_api: UsersAPI) -> None:
         """Test get_users behavior when rate limit is exceeded."""
-        with patch.object(users_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailRateLimitError(
+        with patch.object(users_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailRateLimitError(
                 "Rate limit exceeded"
             )
 
@@ -152,20 +150,20 @@ class TestUsersAPI:
         self, users_api: UsersAPI, sample_user_data: dict
     ) -> None:
         """Test get_current_user method."""
-        with patch.object(users_api, "_api_request") as mock_request:
-            mock_request.return_value = sample_user_data
+        with patch.object(users_api, "_get") as mock_get:
+            mock_get.return_value = sample_user_data
 
             result = users_api.get_current_user()
 
-            mock_request.assert_called_once_with("GET", "get_current_user")
+            mock_get.assert_called_once_with("get_current_user")
             assert result == sample_user_data
 
     def test_get_current_user_api_request_failure(
         self, users_api: UsersAPI
     ) -> None:
         """Test get_current_user behavior when API request fails."""
-        with patch.object(users_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAPIError("API request failed")
+        with patch.object(users_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAPIError("API request failed")
 
             with pytest.raises(TestRailAPIError, match="API request failed"):
                 users_api.get_current_user()
@@ -174,8 +172,8 @@ class TestUsersAPI:
         self, users_api: UsersAPI
     ) -> None:
         """Test get_current_user behavior when authentication fails."""
-        with patch.object(users_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAuthenticationError(
+        with patch.object(users_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAuthenticationError(
                 "Authentication failed"
             )
 
@@ -188,8 +186,8 @@ class TestUsersAPI:
         self, users_api: UsersAPI
     ) -> None:
         """Test get_current_user behavior when rate limit is exceeded."""
-        with patch.object(users_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailRateLimitError(
+        with patch.object(users_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailRateLimitError(
                 "Rate limit exceeded"
             )
 
@@ -200,13 +198,12 @@ class TestUsersAPI:
 
     def test_get_user_by_email(self, users_api: UsersAPI) -> None:
         """Test get_user_by_email passes the email via params."""
-        with patch.object(users_api, "_api_request") as mock_request:
-            mock_request.return_value = {"id": 1, "email": "test@example.com"}
+        with patch.object(users_api, "_get") as mock_get:
+            mock_get.return_value = {"id": 1, "email": "test@example.com"}
 
             result = users_api.get_user_by_email(email="test@example.com")
 
-            mock_request.assert_called_once_with(
-                "GET",
+            mock_get.assert_called_once_with(
                 "get_user_by_email",
                 params={"email": "test@example.com"},
             )
@@ -222,16 +219,15 @@ class TestUsersAPI:
         decoded server-side as a space. Passing the email via params lets
         _build_url urlencode it correctly.
         """
-        with patch.object(users_api, "_api_request") as mock_request:
-            mock_request.return_value = {
+        with patch.object(users_api, "_get") as mock_get:
+            mock_get.return_value = {
                 "id": 2,
                 "email": "user+qa@example.com",
             }
 
             result = users_api.get_user_by_email(email="user+qa@example.com")
 
-            mock_request.assert_called_once_with(
-                "GET",
+            mock_get.assert_called_once_with(
                 "get_user_by_email",
                 params={"email": "user+qa@example.com"},
             )
@@ -253,8 +249,8 @@ class TestUsersAPI:
         self, users_api: UsersAPI
     ) -> None:
         """Test get_user_by_email behavior when API request fails."""
-        with patch.object(users_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAPIError("API request failed")
+        with patch.object(users_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAPIError("API request failed")
 
             with pytest.raises(TestRailAPIError, match="API request failed"):
                 users_api.get_user_by_email(email="test@example.com")
@@ -263,8 +259,8 @@ class TestUsersAPI:
         self, users_api: UsersAPI
     ) -> None:
         """Test get_user_by_email behavior when authentication fails."""
-        with patch.object(users_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAuthenticationError(
+        with patch.object(users_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAuthenticationError(
                 "Authentication failed"
             )
 
@@ -277,8 +273,8 @@ class TestUsersAPI:
         self, users_api: UsersAPI
     ) -> None:
         """Test get_user_by_email behavior when rate limit is exceeded."""
-        with patch.object(users_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailRateLimitError(
+        with patch.object(users_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailRateLimitError(
                 "Rate limit exceeded"
             )
 
@@ -289,16 +285,16 @@ class TestUsersAPI:
 
     def test_api_request_failure(self, users_api: UsersAPI) -> None:
         """Test behavior when API request fails."""
-        with patch.object(users_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAPIError("API request failed")
+        with patch.object(users_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAPIError("API request failed")
 
             with pytest.raises(TestRailAPIError, match="API request failed"):
                 users_api.get_user(user_id=1)
 
     def test_authentication_error(self, users_api: UsersAPI) -> None:
         """Test behavior when authentication fails."""
-        with patch.object(users_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailAuthenticationError(
+        with patch.object(users_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailAuthenticationError(
                 "Authentication failed"
             )
 
@@ -309,8 +305,8 @@ class TestUsersAPI:
 
     def test_rate_limit_error(self, users_api: UsersAPI) -> None:
         """Test behavior when rate limit is exceeded."""
-        with patch.object(users_api, "_api_request") as mock_request:
-            mock_request.side_effect = TestRailRateLimitError(
+        with patch.object(users_api, "_get") as mock_get:
+            mock_get.side_effect = TestRailRateLimitError(
                 "Rate limit exceeded"
             )
 


### PR DESCRIPTION
## Summary

- Migrates all remaining `_api_request("GET", ...)` calls in submodules to `self._get(...)` — affects `plans`, `priorities`, `result_fields`, `roles`, `templates`, and `users`
- Migrates all remaining `_api_request("POST", ...)` calls in `plans` to `self._post(...)`
- Updates the corresponding test mocks in `test_plans.py`, `test_priorities.py`, `test_result_fields.py`, `test_roles.py`, `test_templates.py`, and `test_users.py` from `_api_request` to `_get`/`_post` per the project test-writing standards
- All 613 tests pass; ruff clean

Closes #156