### PR TITLE
docs: add consumer usage guide

### DIFF
--- a/.claude/skills/testrail/SKILL.md
+++ b/.claude/skills/testrail/SKILL.md
@@ -64,13 +64,13 @@ TESTRAIL_API_KEY=your-api-key
 
 ## API Access Pattern
 
-All 23 modules are properties on the `api` object:
+All 24 modules are properties on the `api` object:
 
 ```python
 api.projects.get_projects()
 api.cases.get_case(case_id=123)
 api.runs.add_run(project_id=1, name="Sprint 42")
-api.results.add_result(run_id=1, case_id=123, status_id=1)
+api.results.add_result_for_case(run_id=1, case_id=123, status_id=1)
 ```
 
 ## Return Types
@@ -175,8 +175,8 @@ cases = api.cases.get_cases(project_id=1, suite_id=2)
 # Create a run
 run = api.runs.add_run(project_id=1, name="Regression", suite_id=2, include_all=True)
 
-# Record a result
-api.results.add_result(run_id=run['id'], case_id=123, status_id=1, comment="Passed")
+# Record a result by case ID within a run
+api.results.add_result_for_case(run_id=run['id'], case_id=123, status_id=1, comment="Passed")
 
 # Bulk results
 api.results.add_results_for_cases(run_id=run['id'], results=[
@@ -187,8 +187,9 @@ api.results.add_results_for_cases(run_id=run['id'], results=[
 # Close a run
 api.runs.close_run(run_id=run['id'])
 
-# Get run stats
-stats = api.runs.get_run_stats(run_id=run['id'])
+# Get run pass/fail counts (fields on the run object itself)
+run_data = api.runs.get_run(run_id=run['id'])
+print(f"Passed: {run_data['passed_count']}, Failed: {run_data['failed_count']}")
 ```
 
 ## Elapsed Time Format
@@ -199,6 +200,7 @@ Use strings: `"30s"`, `"2m"`, `"1h 30m"`, `"2h 15m 30s"`
 
 For detailed information, consult these reference files as needed:
 
-- **`references/modules-quick-reference.md`** -- All 23 modules with methods and required params
+- **`references/modules-quick-reference.md`** -- All 24 modules with methods and required params
 - **`references/cases-and-custom-fields.md`** -- Custom field types, validation, and complete examples
 - **`references/workflows.md`** -- Full Python script examples for common multi-step workflows
+- **[USAGE.md](../../../../USAGE.md)** -- Canonical human-facing consumer usage guide (auth, workflows, gotchas)

--- a/.claude/skills/testrail/references/modules-quick-reference.md
+++ b/.claude/skills/testrail/references/modules-quick-reference.md
@@ -11,6 +11,7 @@ All methods use keyword arguments. Return types are `dict` or `list[dict]`.
 - [configurations](#apiconfigurations)
 - [datasets](#apidatasets)
 - [groups](#apigroups)
+- [labels](#apilabels)
 - [milestones](#apimilestones)
 - [plans](#apiplans)
 - [priorities](#apipriorities)
@@ -33,13 +34,18 @@ All methods use keyword arguments. Return types are `dict` or `list[dict]`.
 
 | Method | Required Params | Description |
 |--------|----------------|-------------|
-| `add_attachment(entity_type, entity_id, file_path)` | entity_type, entity_id, file_path | Upload attachment |
+| `add_attachment_to_case(case_id, file_path)` | case_id, file_path | Upload attachment to a case |
+| `add_attachment_to_plan(plan_id, file_path)` | plan_id, file_path | Upload attachment to a plan |
+| `add_attachment_to_plan_entry(plan_id, entry_id, file_path)` | plan_id, entry_id, file_path | Upload attachment to a plan entry |
+| `add_attachment_to_result(result_id, file_path)` | result_id, file_path | Upload attachment to a result |
+| `add_attachment_to_run(run_id, file_path)` | run_id, file_path | Upload attachment to a run |
+| `get_attachments_for_case(case_id)` | case_id | List attachments on a case |
+| `get_attachments_for_plan(plan_id)` | plan_id | List attachments on a plan |
+| `get_attachments_for_plan_entry(plan_id, entry_id)` | plan_id, entry_id | List attachments on a plan entry |
+| `get_attachments_for_run(run_id)` | run_id | List attachments on a run |
+| `get_attachments_for_test(test_id)` | test_id | List attachments on a test |
+| `get_attachment(attachment_id)` | attachment_id | Download attachment (returns bytes) |
 | `delete_attachment(attachment_id)` | attachment_id | Delete attachment |
-| `get_attachment(attachment_id)` | attachment_id | Get attachment metadata |
-| `get_attachment_content(attachment_id)` | attachment_id | Download attachment content |
-| `get_attachments(entity_type, entity_id)` | entity_type, entity_id | List attachments |
-
-Entity types: `"case"`, `"run"`, `"plan"`, `"result"`, `"test"`
 
 ## api.bdd
 
@@ -70,13 +76,17 @@ Optional params for `add_case`/`update_case`: `type_id`, `priority_id`, `estimat
 
 ## api.configurations
 
+Configurations are two-level: groups contain individual configs.
+
 | Method | Required Params | Description |
 |--------|----------------|-------------|
-| `add_configuration(project_id, name)` | project_id, name | Create configuration |
-| `delete_configuration(config_id)` | config_id | Delete configuration |
-| `get_configuration(config_id)` | config_id | Get configuration |
-| `get_configurations(project_id)` | project_id | List configurations |
-| `update_configuration(config_id, **kwargs)` | config_id | Update configuration |
+| `get_configs(project_id)` | project_id | List all config groups (each has a `configs` list) |
+| `add_config_group(project_id, name)` | project_id, name | Create a config group |
+| `add_config(config_group_id, name)` | config_group_id, name | Create a config within a group |
+| `update_config_group(config_group_id, name)` | config_group_id, name | Update a config group |
+| `update_config(config_id, name)` | config_id, name | Update a config |
+| `delete_config_group(config_group_id)` | config_group_id | Delete a config group |
+| `delete_config(config_id)` | config_id | Delete a config |
 
 ## api.datasets
 
@@ -87,17 +97,25 @@ Optional params for `add_case`/`update_case`: `type_id`, `priority_id`, `estimat
 
 ## api.groups
 
+Groups are instance-level (not project-scoped). Requires TestRail 7.5+.
+
 | Method | Required Params | Description |
 |--------|----------------|-------------|
-| `add_group(project_id, name)` | project_id, name | Create group |
-| `add_group_to_suite(group_id, suite_id)` | group_id, suite_id | Associate group with suite |
-| `delete_group(group_id)` | group_id | Delete group |
 | `get_group(group_id)` | group_id | Get group |
-| `get_group_cases(group_id)` | group_id | Get cases in group |
-| `get_group_suites(group_id)` | group_id | Get suites for group |
-| `get_groups(project_id)` | project_id | List groups |
-| `remove_group_from_suite(group_id, suite_id)` | group_id, suite_id | Disassociate group from suite |
+| `get_groups()` | (none) | List all groups on the instance |
+| `add_group(name)` | name | Create group (optional: user_ids) |
 | `update_group(group_id)` | group_id | Update group |
+| `delete_group(group_id)` | group_id | Delete group |
+
+## api.labels
+
+| Method | Required Params | Description |
+|--------|----------------|-------------|
+| `get_label(label_id)` | label_id | Get label |
+| `get_labels(project_id)` | project_id | List labels for a project |
+| `add_label(project_id, title)` | project_id, title | Create label |
+| `update_label(label_id)` | label_id | Update label |
+| `delete_label(label_id)` | label_id | Delete label |
 
 ## api.milestones
 
@@ -114,13 +132,18 @@ Optional params for `add_case`/`update_case`: `type_id`, `priority_id`, `estimat
 
 | Method | Required Params | Description |
 |--------|----------------|-------------|
+| `get_plan(plan_id)` | plan_id | Get plan with entries |
+| `get_plans(project_id)` | project_id | List plans |
 | `add_plan(project_id, name)` | project_id, name | Create test plan |
+| `update_plan(plan_id)` | plan_id | Update plan metadata |
 | `close_plan(plan_id)` | plan_id | Close test plan |
 | `delete_plan(plan_id)` | plan_id | Delete test plan |
-| `get_plan(plan_id)` | plan_id | Get plan with entries |
-| `get_plan_stats(plan_id)` | plan_id | Get plan statistics |
-| `get_plans(project_id)` | project_id | List plans |
-| `update_plan(plan_id)` | plan_id | Update plan / add entries |
+| `add_plan_entry(plan_id, suite_id)` | plan_id, suite_id | Add an entry (run group) to a plan |
+| `update_plan_entry(plan_id, entry_id)` | plan_id, entry_id | Update a plan entry |
+| `delete_plan_entry(plan_id, entry_id)` | plan_id, entry_id | Delete a plan entry |
+| `add_run_to_plan_entry(plan_id, entry_id, config_ids)` | plan_id, entry_id, config_ids | Add a run to a plan entry |
+| `update_run_in_plan_entry(run_id)` | run_id | Update a run within a plan entry |
+| `delete_run_from_plan_entry(run_id)` | run_id | Delete a run from a plan entry |
 
 ## api.priorities
 
@@ -171,15 +194,15 @@ Optional params for `add_case`/`update_case`: `type_id`, `priority_id`, `estimat
 
 | Method | Required Params | Description |
 |--------|----------------|-------------|
-| `add_result(run_id, case_id, status_id)` | run_id, case_id, status_id | Record single result |
-| `add_result_for_run(run_id, status_id)` | run_id, status_id | Add result for run |
-| `add_results(run_id, results)` | run_id, results | Batch add results |
+| `add_result(test_id, status_id)` | test_id, status_id | Record result by test instance ID |
+| `add_result_for_case(run_id, case_id, status_id)` | run_id, case_id, status_id | Record result by case ID within a run |
+| `add_results(run_id, results)` | run_id, results | Batch add results by test instance ID |
 | `add_results_for_cases(run_id, results)` | run_id, results | Batch add results by case_id |
-| `get_results(run_id)` | run_id | Get results |
-| `get_results_for_case(run_id, case_id)` | run_id, case_id | Get results for specific case |
+| `get_results(test_id)` | test_id | Get results for a test instance |
+| `get_results_for_case(run_id, case_id)` | run_id, case_id | Get results for a case in a run |
 | `get_results_for_run(run_id)` | run_id | Get all results for a run |
 
-Optional params for `add_result`: `comment`, `version`, `elapsed`, `defects`
+Optional params for `add_result` / `add_result_for_case`: `comment`, `version`, `elapsed`, `defects`
 
 ## api.roles
 

--- a/.claude/skills/testrail/references/workflows.md
+++ b/.claude/skills/testrail/references/workflows.md
@@ -98,9 +98,9 @@ print(f"Created run: {run['name']} (ID: {run_id})")
 tests = api.tests.get_tests(run_id=run_id)
 print(f"Run has {len(tests)} tests")
 
-# 3. Record results for individual tests
+# 3. Record results for individual tests by case ID
 for test in tests:
-    result = api.results.add_result(
+    result = api.results.add_result_for_case(
         run_id=run_id,
         case_id=test['case_id'],
         status_id=1,                    # 1=Passed
@@ -109,9 +109,9 @@ for test in tests:
         version="1.2.0"
     )
 
-# 4. Check run progress
-stats = api.runs.get_run_stats(run_id=run_id)
-print(f"Progress: {stats}")
+# 4. Check run progress (pass/fail counts are fields on the run object)
+run_data = api.runs.get_run(run_id=run_id)
+print(f"Passed: {run_data['passed_count']}, Failed: {run_data['failed_count']}, Untested: {run_data['untested_count']}")
 
 # 5. Close the run
 api.runs.close_run(run_id=run_id)
@@ -182,8 +182,13 @@ plan = api.plans.add_plan(
 )
 plan_id = plan['id']
 
-# 2. Monitor plan progress
-stats = api.plans.get_plan_stats(plan_id=plan_id)
+# 2. Add entries (runs) to the plan
+entry = api.plans.add_plan_entry(
+    plan_id=plan_id,
+    suite_id=5,
+    name="Smoke tests",
+    include_all=True,
+)
 
 # 3. Get full plan details (includes entries/runs)
 plan_details = api.plans.get_plan(plan_id=plan_id)
@@ -205,11 +210,9 @@ for r in results:
 # Results for a specific case in a run
 case_results = api.results.get_results_for_case(run_id=1, case_id=123)
 
-# Run statistics
-run_stats = api.runs.get_run_stats(run_id=1)
-
-# Status counts
-status_counts = api.statuses.get_status_counts(run_id=1)
+# Pass/fail counts are fields on the run object itself (not a separate endpoint)
+run = api.runs.get_run(run_id=1)
+print(f"Passed: {run['passed_count']}, Failed: {run['failed_count']}, Untested: {run['untested_count']}")
 ```
 
 ## Create Test Cases

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@
 
 TRAM is a comprehensive Python wrapper for the TestRail API that provides easy access to all TestRail functionalities.
 
+## Usage
+
+For a full consumer usage guide covering authentication, client initialization, common workflows,
+response shapes, exception handling, and gotchas, see **[USAGE.md](USAGE.md)**.
+
 ## Features
 
 - **NEW**: Comprehensive exception handling with specific error types

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,436 @@
+# TRAM Consumer Usage Guide
+
+This guide covers how to use `testrail-api-module` (TRAM) in your own code to interact with the
+TestRail API. For contributor setup, branching strategy, and release process, see
+[CLAUDE.md](CLAUDE.md) and [CONTRIBUTING](https://github.com/trtmn/testrail_api_module).
+
+## Contents
+
+- [Installation](#installation)
+- [Authentication](#authentication)
+- [Client Initialization](#client-initialization)
+- [API Surface Overview](#api-surface-overview)
+- [Response Shapes](#response-shapes)
+- [Common Workflows](#common-workflows)
+  - [Explore project structure](#explore-project-structure)
+  - [Create a test run and record results](#create-a-test-run-and-record-results)
+  - [Bulk result recording](#bulk-result-recording)
+  - [Create a test plan](#create-a-test-plan)
+  - [Create a test case](#create-a-test-case)
+  - [Upload an attachment](#upload-an-attachment)
+- [Exception Handling](#exception-handling)
+- [Gotchas](#gotchas)
+- [Context Manager](#context-manager)
+
+---
+
+## Installation
+
+```bash
+pip install testrail-api-module
+```
+
+Requires Python 3.11+. Runtime dependency: `requests` (pulled in automatically).
+
+---
+
+## Authentication
+
+TestRail supports two authentication methods:
+
+| Method | Parameter | When to use |
+|---|---|---|
+| API key | `api_key="..."` | Recommended -- generate one in TestRail under **My Settings > API Keys** |
+| Password | `password="..."` | Legacy -- works but API key is preferred |
+
+Exactly one of `api_key` or `password` must be supplied. Credentials are sent as HTTP Basic Auth
+on every request.
+
+**Recommended: store credentials in environment variables** (never hard-code them):
+
+```bash
+# .env (add to .gitignore)
+TESTRAIL_BASE_URL=https://your-instance.testrail.io
+TESTRAIL_USERNAME=you@example.com
+TESTRAIL_API_KEY=your-api-key
+```
+
+---
+
+## Client Initialization
+
+```python
+import os
+from testrail_api_module import TestRailAPI
+
+api = TestRailAPI(
+    base_url=os.environ["TESTRAIL_BASE_URL"],
+    username=os.environ["TESTRAIL_USERNAME"],
+    api_key=os.environ.get("TESTRAIL_API_KEY"),
+    password=os.environ.get("TESTRAIL_PASSWORD"),
+    timeout=30,  # optional, seconds (default: 30)
+)
+```
+
+Or with `python-dotenv` to load `.env` automatically:
+
+```python
+from dotenv import load_dotenv
+load_dotenv()
+
+import os
+from testrail_api_module import TestRailAPI
+
+api = TestRailAPI(
+    base_url=os.environ["TESTRAIL_BASE_URL"],
+    username=os.environ["TESTRAIL_USERNAME"],
+    api_key=os.environ.get("TESTRAIL_API_KEY"),
+)
+```
+
+The client validates `base_url` format and raises `ValueError` immediately if neither
+`api_key` nor `password` is provided.
+
+---
+
+## API Surface Overview
+
+All 24 submodule APIs are attributes on the `api` object. Every method uses keyword arguments
+and returns either `dict` or `list[dict]`. No method returns `None` -- failures raise exceptions.
+
+| Attribute | Purpose |
+|---|---|
+| `api.attachments` | Upload, download, and list file attachments |
+| `api.bdd` | Import/export BDD (Gherkin) feature files |
+| `api.cases` | CRUD for test cases, custom field handling |
+| `api.configurations` | Manage config groups and individual configs |
+| `api.datasets` | Manage test datasets |
+| `api.groups` | Manage TestRail user groups |
+| `api.labels` | Manage labels (tags for cases/runs) |
+| `api.milestones` | Track milestones and sprints |
+| `api.plans` | Create and manage test plans (groups of runs) |
+| `api.priorities` | Manage test case priorities |
+| `api.projects` | Top-level project management |
+| `api.reports` | Create and run reports |
+| `api.result_fields` | Inspect custom result field definitions |
+| `api.results` | Record and retrieve test results |
+| `api.roles` | Manage user roles |
+| `api.runs` | Create and manage test runs |
+| `api.sections` | Manage sections (folders) within suites |
+| `api.shared_steps` | Reusable step libraries |
+| `api.statuses` | Inspect and manage test statuses |
+| `api.suites` | Manage test suites |
+| `api.templates` | Manage case templates |
+| `api.tests` | Query and record results for test instances |
+| `api.users` | Manage TestRail users |
+| `api.variables` | Manage test variables |
+
+---
+
+## Response Shapes
+
+### Standard responses
+
+- **Single resource** (`get_case`, `get_run`, etc.): returns `dict`
+- **List resources** (`get_cases`, `get_runs`, etc.): returns `list[dict]`
+- **Create/update**: returns `dict` of the created/updated resource
+- **Delete**: returns `{}` (empty dict)
+
+### Pagination
+
+Some list endpoints (notably `get_projects`) may return a pagination envelope on newer TestRail
+versions instead of a plain list:
+
+```python
+response = api.projects.get_projects()
+# Newer TestRail: {"offset": 0, "limit": 250, "size": 5, "_links": {...}, "projects": [...]}
+# Older TestRail: [{"id": 1, ...}, ...]
+projects = response.get("projects", response) if isinstance(response, dict) else response
+```
+
+### Status IDs
+
+| ID | Label    | Meaning                    |
+|----|----------|----------------------------|
+| 1  | Passed   | Test executed successfully |
+| 2  | Blocked  | Cannot execute             |
+| 3  | Untested | Not yet executed           |
+| 4  | Retest   | Needs re-execution         |
+| 5  | Failed   | Test execution failed      |
+
+Custom statuses have IDs above 5. Use `api.statuses.get_statuses()` to discover them.
+
+### Elapsed time format
+
+Pass as strings: `"30s"`, `"2m"`, `"1h 30m"`, `"2h 15m 30s"`.
+
+---
+
+## Common Workflows
+
+### Explore project structure
+
+```python
+# List projects
+response = api.projects.get_projects()
+projects = response.get("projects", response) if isinstance(response, dict) else response
+for p in projects:
+    print(f"{p['name']} (ID: {p['id']})")
+
+# Suites in a project
+suites = api.suites.get_suites(project_id=1)
+
+# Sections in a suite
+sections = api.sections.get_sections(project_id=1, suite_id=suites[0]["id"])
+
+# Cases in a section
+cases = api.cases.get_cases(
+    project_id=1,
+    suite_id=suites[0]["id"],
+    section_id=sections[0]["id"],
+)
+```
+
+### Create a test run and record results
+
+```python
+# Create the run (include_all=True pulls in all cases from the suite)
+run = api.runs.add_run(
+    project_id=1,
+    name="Sprint 42 Regression",
+    suite_id=5,
+    include_all=True,
+    description="Automated regression",
+    milestone_id=3,          # optional
+)
+
+# Record a result for a specific case in the run
+result = api.results.add_result_for_case(
+    run_id=run["id"],
+    case_id=101,
+    status_id=1,             # 1 = Passed
+    comment="All assertions passed",
+    elapsed="2m 30s",
+    version="1.2.0",
+)
+
+# Or record a result by test ID (test instance ID within the run)
+tests = api.tests.get_tests(run_id=run["id"])
+api.results.add_result(
+    test_id=tests[0]["id"],
+    status_id=1,
+)
+
+# Check progress -- pass/fail counts are on the run object itself
+updated_run = api.runs.get_run(run_id=run["id"])
+print(
+    f"Passed: {updated_run['passed_count']}, "
+    f"Failed: {updated_run['failed_count']}, "
+    f"Untested: {updated_run['untested_count']}"
+)
+
+# Close the run
+api.runs.close_run(run_id=run["id"])
+```
+
+### Bulk result recording
+
+Record multiple results in a single API call (much faster than looping):
+
+```python
+api.results.add_results_for_cases(
+    run_id=run["id"],
+    results=[
+        {"case_id": 101, "status_id": 1, "comment": "Passed", "elapsed": "1m"},
+        {"case_id": 102, "status_id": 5, "comment": "Failed", "defects": "BUG-789"},
+        {"case_id": 103, "status_id": 2, "comment": "Blocked by BUG-789"},
+    ],
+)
+```
+
+### Create a test plan
+
+Plans group multiple runs together, useful for multi-config or multi-environment testing.
+
+```python
+plan = api.plans.add_plan(
+    project_id=1,
+    name="Release 2.0 Test Plan",
+    milestone_id=10,
+    description="Full coverage for Release 2.0",
+)
+
+# Add an entry (a run or set of runs) to the plan
+entry = api.plans.add_plan_entry(
+    plan_id=plan["id"],
+    suite_id=5,
+    name="Smoke tests",
+    include_all=True,
+)
+
+# Close the plan when testing is complete
+api.plans.close_plan(plan_id=plan["id"])
+```
+
+### Create a test case
+
+TestRail instances can have required custom fields. Skipping field discovery causes validation
+errors. Always discover requirements first:
+
+```python
+# Step 1: discover required fields for this section's context
+required = api.cases.get_required_case_fields(section_id=123)
+# Returns: {"required_fields": [...], "format_guide": {...}, "context": {...}}
+
+# Step 2: for dropdown/multi-select fields, get option IDs
+options = api.cases.get_field_options(field_name="custom_interface_type")
+# Returns: {"1": "Web", "2": "Mobile", "3": "API", ...}
+
+# Step 3: create the case
+case = api.cases.add_case(
+    section_id=123,
+    title="Verify login with valid credentials",
+    type_id=1,
+    priority_id=3,
+    estimate="15m",
+    refs="JIRA-456",
+    custom_fields={
+        "custom_automation_type": "Manual",
+        "custom_interface_type": ["3"],       # STRING IDs, not ints
+        "custom_steps_separated": [
+            {"content": "Open login page", "expected": "Login form is shown"},
+            {"content": "Enter credentials", "expected": "Fields are populated"},
+            {"content": "Click Sign In",    "expected": "Dashboard loads"},
+        ],
+        "custom_case_test_data_required": False,
+    },
+)
+print(f"Created case {case['id']}: {case['title']}")
+```
+
+**Custom field format rules:**
+
+| Field type | Python format |
+|---|---|
+| String / Text | `"plain text"` |
+| Integer | `42` |
+| Checkbox | `True` or `False` |
+| Dropdown | `"3"` (single string ID) |
+| Multi-select | `["3", "5"]` (array of string IDs, NOT integers) |
+| Separated steps | `[{"content": "...", "expected": "..."}]` -- both keys required and non-empty |
+| Date | `"2026-01-15"` |
+| User | `5` (integer user ID) |
+
+### Upload an attachment
+
+```python
+# Attach a file to a test case
+result = api.attachments.add_attachment_to_case(
+    case_id=123,
+    file_path="path/to/screenshot.png",
+)
+print(f"Attachment ID: {result['attachment_id']}")
+
+# Other entity targets
+api.attachments.add_attachment_to_run(run_id=456, file_path="report.html")
+api.attachments.add_attachment_to_result(result_id=789, file_path="error.png")
+api.attachments.add_attachment_to_plan(plan_id=10, file_path="spec.pdf")
+api.attachments.add_attachment_to_plan_entry(plan_id=10, entry_id=5, file_path="log.txt")
+
+# List attachments
+attachments = api.attachments.get_attachments_for_case(case_id=123)
+attachments = api.attachments.get_attachments_for_run(run_id=456, limit=50)
+
+# Download raw bytes
+data = api.attachments.get_attachment(attachment_id=443)
+with open("downloaded.png", "wb") as f:
+    f.write(data)
+
+# Delete
+api.attachments.delete_attachment(attachment_id=443)
+```
+
+---
+
+## Exception Handling
+
+```python
+from testrail_api_module import (
+    TestRailAPIError,             # base -- catch-all for any API error
+    TestRailAuthenticationError,  # 401 -- bad credentials
+    TestRailRateLimitError,       # 429 -- slow down
+    TestRailAPIException,         # other 4xx/5xx -- has .status_code and .response_text
+)
+
+try:
+    case = api.cases.get_case(case_id=123)
+except TestRailAuthenticationError:
+    print("Invalid credentials -- check TESTRAIL_USERNAME and TESTRAIL_API_KEY")
+except TestRailRateLimitError:
+    print("Rate limit hit -- back off and retry")
+except TestRailAPIException as e:
+    print(f"API error {e.status_code}: {e.response_text}")
+except TestRailAPIError as e:
+    print(f"Unexpected TestRail error: {e}")
+```
+
+The client has built-in retry logic: up to 3 retries with exponential backoff for 429 and 5xx
+responses on GET requests. POST requests are only retried on connection errors (before the
+request reaches the server), never on 429/5xx (to avoid double-writes).
+
+---
+
+## Gotchas
+
+**`get_projects()` may return a pagination envelope.** On newer TestRail versions the response
+is `{"projects": [...], "offset": 0, "limit": 250, ...}` rather than a plain list. Always
+extract the inner list (see [Response Shapes](#response-shapes)).
+
+**Configurations API is two-level** (groups containing individual configs). The old flat
+`get_configurations(project_id)` was removed in v0.6.3. Use:
+
+```python
+config_groups = api.configurations.get_configs(project_id=1)
+# Each group has {"id": ..., "name": ..., "configs": [...]}
+group = api.configurations.add_config_group(project_id=1, name="Browser")
+config = api.configurations.add_config(config_group_id=group["id"], name="Chrome")
+```
+
+**`add_result` vs `add_result_for_case`.** These target different TestRail endpoints:
+
+- `api.results.add_result(test_id=..., status_id=...)` -- records by *test instance ID* (the
+  `id` from `api.tests.get_tests()`)
+- `api.results.add_result_for_case(run_id=..., case_id=..., status_id=...)` -- records by
+  *case ID* within a run (more convenient when you already know the case ID)
+
+**Multi-select custom fields require string IDs.** `["3", "5"]` is correct; `[3, 5]` causes a
+validation error.
+
+**Custom fields must be nested under `custom_fields={}`.** Passing them as top-level keyword
+arguments does nothing.
+
+**Suites are optional for single-suite projects.** In single-suite mode `suite_id` can be
+omitted; multi-suite projects require it.
+
+**The `cases.py` field cache.** `add_case` caches field definitions in memory for performance.
+If you change required field definitions on the TestRail server mid-session, call
+`api.cases.clear_case_fields_cache()` before the next `add_case` call.
+
+---
+
+## Context Manager
+
+The client supports use as a context manager, which closes the underlying HTTP session
+automatically:
+
+```python
+with TestRailAPI(
+    base_url=os.environ["TESTRAIL_BASE_URL"],
+    username=os.environ["TESTRAIL_USERNAME"],
+    api_key=os.environ["TESTRAIL_API_KEY"],
+) as api:
+    projects = api.projects.get_projects()
+# session is closed when the block exits
+```
+
+Or call `api.close()` explicitly when you are done.


### PR DESCRIPTION
## Summary

- Adds `USAGE.md` as a static, human-readable consumer usage guide shipped with the repo and discoverable from PyPI (auth, client init, all 24 API modules, response shapes, common workflows, exception hierarchy, gotchas)
- Adds a brief "Usage" pointer section to `README.md` linking to `USAGE.md`
- Updates `.claude/skills/testrail/` to fix stale API references that were broken by the v0.6.3 parity audit:
  - `add_result(run_id, case_id)` → `add_result_for_case(run_id, case_id)` and `add_result(test_id)` distinction
  - Attachments: old generic `add_attachment(entity_type, ...)` → per-entity methods
  - Configurations: old flat `get_configurations()` → two-level `get_configs()` / `add_config_group()` / `add_config()`
  - Plans: removed non-existent `get_plan_stats`, added `add_plan_entry` / `update_plan_entry` / `delete_plan_entry`
  - Groups: corrected to instance-level (no project_id required)
  - Added missing `api.labels` module to quick reference
  - Fixed `get_run_stats` / `get_status_counts` (removed) → use `get_run()` pass/fail fields directly

## Design rationale

The existing testrail skill already fulfills the Claude-activated usage guidance that issue #96 asks for. What was missing was a **static human-readable doc** that ships with the package for consumers who install from PyPI and don't have access to the skill. `USAGE.md` is that doc — the skill references it rather than duplicating it.

## Test plan

- [ ] `USAGE.md` renders cleanly on GitHub
- [ ] All API method signatures in `USAGE.md` match the current `src/testrail_api_module/` source
- [ ] README "Usage" section links correctly to `USAGE.md`
- [ ] Skill quick reference no longer contains removed methods (`get_run_stats`, `get_plan_stats`, `get_status_counts`, old `add_result`, old attachments API)

Closes #96