### PR TITLE
ci: gate PyPI publish and docs deploy on the test matrix

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,9 +31,18 @@ jobs:
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
 
+  tests:
+    name: Tests
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    # Gate the release on a green matrix at the release commit (the push
+    # that triggered this run is the tagged commit). Publishing must not
+    # proceed if these fail. See issue #186.
+    uses: ./.github/workflows/tests.yml
+
   publish:
     name: Build and publish to PyPI
-    needs: release-please
+    needs: [release-please, tests]
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
 
@@ -70,7 +79,7 @@ jobs:
 
   deploy-docs:
     name: Build and deploy documentation
-    needs: release-please
+    needs: [release-please, tests]
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, development]
   pull_request:
     branches: [main, development]
+  # Reusable: release-please.yml calls this to gate publishing on a green
+  # matrix at the release commit. See issue #186.
+  workflow_call:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

The PyPI publish was never gated on the test suite. `tests.yml` and `release-please.yml` are two independent workflows triggered by the same push to `development`. The `publish` (and `deploy-docs`) jobs in `release-please.yml` depended only on the `release-please` job — never on the Tests workflow — so PyPI publish ran in parallel with the matrix and would proceed regardless of whether tests passed, failed, or were still running.

Observed on the v0.8.0 release (synced by #185): the publish job started at 15:49:44, **7 seconds before** the last test (Python 3.14) finished at 15:49:51. It only appeared to land after tests by coincidence of build timing.

## Fix

- `tests.yml`: add a `workflow_call:` trigger so it is reusable (existing push/PR triggers unchanged).
- `release-please.yml`: add a `tests` job that calls `./.github/workflows/tests.yml` after the release is cut, and change `publish` and `deploy-docs` to `needs: [release-please, tests]`.

The push that triggers `release-please.yml` is the tagged release commit, so the reusable matrix checks out exactly the released code. If the matrix fails, `publish` and `deploy-docs` are skipped and nothing reaches PyPI. `sync-main` is gated transitively through `publish`.

## Verification

- Both workflow files parse as valid YAML.
- `actionlint` passes on the changed files (the one remaining `SC2035` warning is pre-existing in the untouched "Clean previous builds" step).

Closes #186
