### PR TITLE
ci: pass a PAT to release-please-action to avoid bot-PR approval gate

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,6 +27,12 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v5
         with:
+          # A PAT makes the release PR/commits attributable to a real user
+          # instead of github-actions[bot], which is otherwise gated behind
+          # manual workflow-run approval even on same-repo branches. Falls
+          # back to the default token until RELEASE_PLEASE_PAT is set.
+          # See issue #196.
+          token: ${{ secrets.RELEASE_PLEASE_PAT || secrets.GITHUB_TOKEN }}
           target-branch: development
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json


### PR DESCRIPTION
## Problem

The `Tests` workflow run on the release-please PR (#188, #195) repeatedly came back `action_required` with zero jobs, requiring a maintainer to manually approve/rerun before it executes.

## Root cause

GitHub shipped a security change on 2026-06-11 ([Bot-created pull requests can run workflows if approved](https://github.blog/changelog/2026-06-11-bot-created-pull-requests-can-run-workflows-if-approved/)): workflow runs on PRs authored by `github-actions[bot]` now require manual approval, even on same-repo branches (not forks). `release-please-action` pushes/opens its PR using the default `GITHUB_TOKEN`, so it's attributed to `github-actions[bot]` and gets gated every time it updates the PR.

Ruled out the repo's fork-PR-contributor-approval policy (`GET /repos/trtmn/testrail_api_module/actions/permissions/fork-pr-contributor-approval` → already `first_time_contributors`; also the release-please PR's `head.repo` == `base.repo`, confirming it's not a fork) — this is the newer, separate bot-PR gate, which has no repo-level opt-out.

## Fix

Pass a personal access token (PAT) to `release-please-action` via its `token` input, so the PR/commits are attributed to a real user account instead of `github-actions[bot]`. PRs authored by a real user aren't subject to the bot-PR approval gate.

```yaml
token: ${{ secrets.RELEASE_PLEASE_PAT || secrets.GITHUB_TOKEN }}
```

Falls back to the current default token until `RELEASE_PLEASE_PAT` is added as a repo secret, so this ships without breaking the existing pipeline.

## Follow-up required (not done by this PR)

A maintainer needs to:
1. Create a fine-grained PAT scoped to this repo only, with **Contents: Read and write** and **Pull requests: Read and write** permissions.
2. Add it as a repo secret: `gh secret set RELEASE_PLEASE_PAT --repo trtmn/testrail_api_module` (run locally so the token value never passes through any AI/chat context).

Until that secret exists, behavior is unchanged (falls back to `GITHUB_TOKEN`) and the approval-gate issue persists.

Closes #196